### PR TITLE
New Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,86 @@
 
 3. In Revit: Go to **Add-ins** > **Settings** > **Refresh** > **Save**
 
+## Testing
+
+The test project uses [Nice3point.TUnit.Revit](https://github.com/Nice3point/RevitUnit) to run integration tests against a live Revit instance. No separate addin installation is required — the framework injects into the running Revit process automatically.
+
+### Prerequisites
+
+- **.NET 8 SDK** — install via `winget install Microsoft.DotNet.SDK.8`
+- **Autodesk Revit 2026** — must be installed and licensed on your machine
+
+### Running Tests
+
+1. Open Revit 2026 and wait for it to fully load
+2. Run the tests from the command line:
+
+```bash
+dotnet test -c Debug.R26 --project revit-mcp-commandset.Tests -r win-x64
+```
+
+> **Note:** The `-r win-x64` flag is required on ARM64 machines because the Revit API assemblies are x64-only.
+
+Alternatively, you can use `dotnet run`:
+
+```bash
+cd revit-mcp-commandset.Tests
+dotnet run -c Debug.R26
+```
+
+### Project Structure
+
+| File | Purpose |
+|------|---------|
+| `revit-mcp-commandset.Tests/AssemblyInfo.cs` | Global `[assembly: TestExecutor<RevitThreadExecutor>]` — applies to all test methods, but hooks still need their own `[HookExecutor<RevitThreadExecutor>]` |
+| `revit-mcp-commandset.Tests/Architecture/` | Tests for level and room creation commands |
+| `revit-mcp-commandset.Tests/DataExtraction/` | Tests for model statistics, room data export, and material quantities |
+| `revit-mcp-commandset.Tests/ColorSplashHandlerTests.cs` | Tests for color override functionality |
+| `revit-mcp-commandset.Tests/TagRoomsHandlerTests.cs` | Tests for room tagging functionality |
+
+### Writing New Tests
+
+Test classes inherit from `RevitApiTest` and use TUnit's async assertion API. All assertions **must be awaited** — without `await`, assertions silently pass without checking anything.
+
+Setup and cleanup hooks require `[HookExecutor<RevitThreadExecutor>]` to run on the Revit thread (the assembly-level `TestExecutor` only covers test methods, not hooks).
+
+```csharp
+public class MyTests : RevitApiTest
+{
+    private static Document _doc = null!;
+    private static string _tempPath = null!;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        var doc = Application.NewProjectDocument(UnitSystem.Imperial);
+        _tempPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.rvt");
+        doc.SaveAs(_tempPath);
+        doc.Close(false);
+        _doc = Application.OpenDocumentFile(_tempPath);
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+        try { File.Delete(_tempPath); } catch { }
+    }
+
+    [Test]
+    public async Task MyTest_Condition_ExpectedResult()
+    {
+        var elements = new FilteredElementCollector(_doc)
+            .WhereElementIsNotElementType()
+            .ToElements();
+
+        await Assert.That(elements.Count).IsGreaterThan(0);
+    }
+}
+```
+
 ## Important Note
 
    - Command names must be identical between `revit-mcp` and `revit-mcp-commandset` repositories, otherwise Claude cannot find them.

--- a/command.json
+++ b/command.json
@@ -29,8 +29,33 @@
       "assemblyPath": "RevitMCPCommandSet.dll"
     },
     {
-      "commandName": "create_Wall",
-      "description": "create a wall",
+      "commandName": "get_selected_elements",
+      "description": "get selected elements",
+      "assemblyPath": "RevitMCPCommandSet.dll"
+    },
+    {
+      "commandName": "create_point_based_element",
+      "description": "Create point-based elements like furniture",
+      "assemblyPath": "RevitMCPCommandSet.dll"
+    },
+    {
+      "commandName": "create_line_based_element",
+      "description": "Create line based element such as wall",
+      "assemblyPath": "RevitMCPCommandSet.dll"
+    },
+    {
+      "commandName": "create_surface_based_element",
+      "description": "Create surface-based elements like floors",
+      "assemblyPath": "RevitMCPCommandSet.dll"
+    },
+    {
+      "commandName": "color_splash",
+      "description": "Color elements by parameter value",
+      "assemblyPath": "RevitMCPCommandSet.dll"
+    },
+    {
+      "commandName": "tag_walls",
+      "description": "Tag all the walls in the model",
       "assemblyPath": "RevitMCPCommandSet.dll"
     },
     {
@@ -38,41 +63,54 @@
       "description": "Deletes elements using ElementId",
       "assemblyPath": "RevitMCPCommandSet.dll"
     },
-	{
-      "commandName": "tag_all_walls",
-      "description": "Tag all the walls in the model",
+    {
+      "commandName": "ai_element_filter",
+      "description": "AI element filter for querying elements by criteria",
       "assemblyPath": "RevitMCPCommandSet.dll"
     },
-	{
-      "commandName": "create_line_based_element",
-      "description": "Create line based element such as wall",
+    {
+      "commandName": "operate_element",
+      "description": "Operate on elements (select, color, hide, isolate, etc)",
       "assemblyPath": "RevitMCPCommandSet.dll"
     },
-	{
+    {
       "commandName": "export_room_data",
       "description": "Extract all rooms with detailed properties including area, volume, perimeter, and parameters",
       "assemblyPath": "RevitMCPCommandSet.dll"
     },
-	{
+    {
       "commandName": "get_material_quantities",
       "description": "Calculate material quantities and takeoffs with area and volume calculations per material",
       "assemblyPath": "RevitMCPCommandSet.dll"
     },
-	{
+    {
       "commandName": "analyze_model_statistics",
       "description": "Analyze model complexity with element counts by category, type, family, and level",
       "assemblyPath": "RevitMCPCommandSet.dll"
-    }
-,
-	{
+    },
+    {
       "commandName": "create_grid",
       "description": "Create grid system with smart spacing generation for project layout (alphabetic/numeric naming)",
       "assemblyPath": "RevitMCPCommandSet.dll"
-    }
-,
-	{
+    },
+    {
       "commandName": "create_structural_framing_system",
       "description": "Create structural beam framing system with configurable spacing and direction",
+      "assemblyPath": "RevitMCPCommandSet.dll"
+    },
+    {
+      "commandName": "create_room",
+      "description": "Create and place rooms at specified locations with custom names, numbers, and properties",
+      "assemblyPath": "RevitMCPCommandSet.dll"
+    },
+    {
+      "commandName": "tag_rooms",
+      "description": "Create tags for all rooms in the current view displaying room name and number",
+      "assemblyPath": "RevitMCPCommandSet.dll"
+    },
+    {
+      "commandName": "create_level",
+      "description": "Create levels at specified elevations with automatic floor plan view generation",
       "assemblyPath": "RevitMCPCommandSet.dll"
     }
   ]

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/revit-mcp-commandset.Tests/Architecture/CreateLevelHandlerTests.cs
+++ b/revit-mcp-commandset.Tests/Architecture/CreateLevelHandlerTests.cs
@@ -1,0 +1,156 @@
+using Autodesk.Revit.DB;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using RevitMCPCommandSet.Models.Architecture;
+using RevitMCPCommandSet.Services.Architecture;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.Architecture;
+
+public class CreateLevelHandlerTests : RevitApiTest
+{
+    private static Document _doc = null!;
+    private static string _tempPath = null!;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        var doc = Application.NewProjectDocument(UnitSystem.Imperial);
+        _tempPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.rvt");
+        doc.SaveAs(_tempPath);
+        doc.Close(false);
+        _doc = Application.OpenDocumentFile(_tempPath);
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+        try { File.Delete(_tempPath); } catch { }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_SingleLevel_CreatesLevelAtCorrectElevation()
+    {
+        var handler = new CreateLevelHandler();
+        handler.SetParameters(new List<LevelInfo>
+        {
+            new LevelInfo { Name = "Single Level Test", Elevation = 3000 }
+        });
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result).IsNotNull();
+        await Assert.That(handler.Result.Success).IsTrue();
+        await Assert.That(handler.Result.Response).IsNotNull();
+        await Assert.That(handler.Result.Response.Count).IsEqualTo(1);
+        await Assert.That(handler.Result.Response[0].Elevation).IsEqualTo(3000);
+        await Assert.That(handler.Result.Response[0].AlreadyExisted).IsFalse();
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_SetName_LevelNameApplied()
+    {
+        var handler = new CreateLevelHandler();
+        handler.SetParameters(new List<LevelInfo>
+        {
+            new LevelInfo { Name = "Custom Name Level", Elevation = 5000 }
+        });
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result.Success).IsTrue();
+        await Assert.That(handler.Result.Response[0].Name).IsEqualTo("Custom Name Level");
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_WithFloorPlan_FloorPlanViewCreated()
+    {
+        var handler = new CreateLevelHandler();
+        handler.SetParameters(new List<LevelInfo>
+        {
+            new LevelInfo { Name = "FloorPlan Level", Elevation = 7000, CreateFloorPlan = true, CreateCeilingPlan = false }
+        });
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result.Success).IsTrue();
+        await Assert.That(handler.Result.Response[0].FloorPlanViewName).IsNotNull();
+        await Assert.That(handler.Result.Response[0].CeilingPlanViewName).IsNull();
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_WithCeilingPlan_CeilingPlanViewCreated()
+    {
+        var handler = new CreateLevelHandler();
+        handler.SetParameters(new List<LevelInfo>
+        {
+            new LevelInfo { Name = "CeilingPlan Level", Elevation = 9000, CreateFloorPlan = false, CreateCeilingPlan = true }
+        });
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result.Success).IsTrue();
+        await Assert.That(handler.Result.Response[0].CeilingPlanViewName).IsNotNull();
+        await Assert.That(handler.Result.Response[0].FloorPlanViewName).IsNull();
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_DuplicateName_ReportsAlreadyExisted()
+    {
+        // First call: create the level
+        var handler1 = new CreateLevelHandler();
+        handler1.SetParameters(new List<LevelInfo>
+        {
+            new LevelInfo { Name = "Dup Test Level", Elevation = 11000 }
+        });
+        handler1.RunOnDocument(_doc);
+        await Assert.That(handler1.Result.Success).IsTrue();
+        await Assert.That(handler1.Result.Response[0].AlreadyExisted).IsFalse();
+
+        // Second call: same name should report already existed
+        var handler2 = new CreateLevelHandler();
+        handler2.SetParameters(new List<LevelInfo>
+        {
+            new LevelInfo { Name = "Dup Test Level", Elevation = 12000 }
+        });
+        handler2.RunOnDocument(_doc);
+
+        await Assert.That(handler2.Result.Success).IsTrue();
+        await Assert.That(handler2.Result.Response[0].AlreadyExisted).IsTrue();
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_MultipleLevels_AllCreatedAtCorrectElevations()
+    {
+        var levels = new List<LevelInfo>
+        {
+            new LevelInfo { Name = "Batch A", Elevation = 0 },
+            new LevelInfo { Name = "Batch B", Elevation = 3000 },
+            new LevelInfo { Name = "Batch C", Elevation = 6000 },
+            new LevelInfo { Name = "Batch D", Elevation = 9000 }
+        };
+
+        var handler = new CreateLevelHandler();
+        handler.SetParameters(levels);
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result.Success).IsTrue();
+        await Assert.That(handler.Result.Response.Count).IsEqualTo(4);
+
+        for (int i = 0; i < levels.Count; i++)
+        {
+            await Assert.That(handler.Result.Response[i].Name).IsEqualTo(levels[i].Name);
+            await Assert.That(handler.Result.Response[i].Elevation).IsEqualTo(levels[i].Elevation);
+        }
+    }
+}

--- a/revit-mcp-commandset.Tests/Architecture/CreateRoomHandlerTests.cs
+++ b/revit-mcp-commandset.Tests/Architecture/CreateRoomHandlerTests.cs
@@ -1,0 +1,255 @@
+using Autodesk.Revit.DB;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using RevitMCPCommandSet.Models.Architecture;
+using RevitMCPCommandSet.Models.Common;
+using RevitMCPCommandSet.Services.Architecture;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.Architecture;
+
+public class CreateRoomHandlerTests : RevitApiTest
+{
+    private static Document _doc = null!;
+    private static string _tempPath = null!;
+#pragma warning disable TUnit0023 // Revit elements are disposed when the document is closed
+    private static Level _level = null!;
+#pragma warning restore TUnit0023
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        var doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using (var tx = new Transaction(doc, "Setup Room Test Environment"))
+        {
+            tx.Start();
+
+            _level = Level.Create(doc, 0.0);
+            _level.Name = "Room Handler Test Level";
+
+            // Each test gets its own exclusive enclosure(s) to avoid isolation issues
+            // Test 1 (SingleRoom): enclosure at x=0
+            CreateEnclosure(doc, _level.Id, 0, 0, 10);
+            // Test 2 (SetNameAndNumber): enclosure at x=20
+            CreateEnclosure(doc, _level.Id, 20, 0, 10);
+            // Test 3 (SetDepartmentAndComments): enclosure at x=40
+            CreateEnclosure(doc, _level.Id, 40, 0, 10);
+            // Test 4 (DuplicateNumber): two enclosures at x=60, x=80
+            CreateEnclosure(doc, _level.Id, 60, 0, 10);
+            CreateEnclosure(doc, _level.Id, 80, 0, 10);
+            // Test 5 (MultipleRooms): two enclosures at x=100, x=120
+            CreateEnclosure(doc, _level.Id, 100, 0, 10);
+            CreateEnclosure(doc, _level.Id, 120, 0, 10);
+            // Test 6 (WithLevelId): enclosure at x=140
+            CreateEnclosure(doc, _level.Id, 140, 0, 10);
+
+            tx.Commit();
+        }
+
+        _tempPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.rvt");
+        doc.SaveAs(_tempPath);
+        doc.Close(false);
+        _doc = Application.OpenDocumentFile(_tempPath);
+
+        // Re-find the level in the reopened document
+        _level = new FilteredElementCollector(_doc)
+            .OfClass(typeof(Level))
+            .Cast<Level>()
+            .First(l => l.Name == "Room Handler Test Level");
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+        try { File.Delete(_tempPath); } catch { }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_SingleRoom_CreatesRoomWithArea()
+    {
+        var handler = new CreateRoomHandler();
+        handler.SetParameters(new List<RoomCreationInfo>
+        {
+            new RoomCreationInfo
+            {
+                Name = "Office",
+                Number = "100",
+                Location = new JZPoint(5 * 304.8, 5 * 304.8, 0) // Center of first enclosure
+            }
+        });
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result).IsNotNull();
+        await Assert.That(handler.Result.Success).IsTrue();
+        await Assert.That(handler.Result.Response).IsNotNull();
+        await Assert.That(handler.Result.Response.Count).IsEqualTo(1);
+        await Assert.That(handler.Result.Response[0].Name).IsEqualTo("Office");
+        await Assert.That(handler.Result.Response[0].Area).IsGreaterThan(0);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_SetNameAndNumber_PropertiesApplied()
+    {
+        var handler = new CreateRoomHandler();
+        handler.SetParameters(new List<RoomCreationInfo>
+        {
+            new RoomCreationInfo
+            {
+                Name = "Conference Room",
+                Number = "200",
+                Location = new JZPoint(25 * 304.8, 5 * 304.8, 0) // Center of second enclosure
+            }
+        });
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result.Success).IsTrue();
+        await Assert.That(handler.Result.Response[0].Name).IsEqualTo("Conference Room");
+        await Assert.That(handler.Result.Response[0].Number).IsEqualTo("200");
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_SetDepartmentAndComments_ParametersSet()
+    {
+        var handler = new CreateRoomHandler();
+        handler.SetParameters(new List<RoomCreationInfo>
+        {
+            new RoomCreationInfo
+            {
+                Name = "Lab Room",
+                Number = "300",
+                Location = new JZPoint(45 * 304.8, 5 * 304.8, 0), // Center of third enclosure
+                Department = "Engineering",
+                Comments = "Test comment"
+            }
+        });
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result.Success).IsTrue();
+
+        // Verify room was created and properties set by checking the Revit element
+        var room = _doc.GetElement(new ElementId(handler.Result.Response[0].Id)) as Autodesk.Revit.DB.Architecture.Room;
+        await Assert.That(room).IsNotNull();
+
+        var deptParam = room.get_Parameter(BuiltInParameter.ROOM_DEPARTMENT);
+        await Assert.That(deptParam?.AsString()).IsEqualTo("Engineering");
+
+        var commentsParam = room.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+        await Assert.That(commentsParam?.AsString()).IsEqualTo("Test comment");
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_DuplicateNumber_UniqueNumberGenerated()
+    {
+        // Create first room with number "400" in enclosure at x=60
+        var handler1 = new CreateRoomHandler();
+        handler1.SetParameters(new List<RoomCreationInfo>
+        {
+            new RoomCreationInfo
+            {
+                Name = "Room A",
+                Number = "400",
+                Location = new JZPoint(65 * 304.8, 5 * 304.8, 0)
+            }
+        });
+        handler1.RunOnDocument(_doc);
+        await Assert.That(handler1.Result.Success).IsTrue();
+
+        // Create second room with same number in enclosure at x=80 - should get a unique number
+        var handler2 = new CreateRoomHandler();
+        handler2.SetParameters(new List<RoomCreationInfo>
+        {
+            new RoomCreationInfo
+            {
+                Name = "Room B",
+                Number = "400",
+                Location = new JZPoint(85 * 304.8, 5 * 304.8, 0)
+            }
+        });
+        handler2.RunOnDocument(_doc);
+
+        await Assert.That(handler2.Result.Success).IsTrue();
+        // The assigned number should differ from "400" since that number is already taken
+        await Assert.That(handler2.Result.Response[0].RequestedNumber).IsEqualTo("400");
+        await Assert.That(handler2.Result.Response[0].Number).IsNotEqualTo("400");
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_MultipleRooms_AllCreatedSuccessfully()
+    {
+        var handler = new CreateRoomHandler();
+        handler.SetParameters(new List<RoomCreationInfo>
+        {
+            new RoomCreationInfo
+            {
+                Name = "Multi Room 1",
+                Number = "500",
+                Location = new JZPoint(105 * 304.8, 5 * 304.8, 0) // Enclosure at x=100
+            },
+            new RoomCreationInfo
+            {
+                Name = "Multi Room 2",
+                Number = "501",
+                Location = new JZPoint(125 * 304.8, 5 * 304.8, 0) // Enclosure at x=120
+            }
+        });
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result.Success).IsTrue();
+        await Assert.That(handler.Result.Response.Count).IsEqualTo(2);
+        await Assert.That(handler.Result.Response[0].Name).IsEqualTo("Multi Room 1");
+        await Assert.That(handler.Result.Response[1].Name).IsEqualTo("Multi Room 2");
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_WithLevelId_RoomCreatedOnCorrectLevel()
+    {
+        var handler = new CreateRoomHandler();
+        handler.SetParameters(new List<RoomCreationInfo>
+        {
+            new RoomCreationInfo
+            {
+                Name = "Level Room",
+                Number = "600",
+                Location = new JZPoint(145 * 304.8, 5 * 304.8, 0), // Enclosure at x=140
+                LevelId = (int)_level.Id.Value
+            }
+        });
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.Result.Success).IsTrue();
+        await Assert.That(handler.Result.Response[0].LevelName).IsEqualTo("Room Handler Test Level");
+    }
+
+    #region Helper Methods
+
+    private static void CreateEnclosure(Document doc, ElementId levelId, double x, double y, double size)
+    {
+        var p1 = new XYZ(x, y, 0);
+        var p2 = new XYZ(x + size, y, 0);
+        var p3 = new XYZ(x + size, y + size, 0);
+        var p4 = new XYZ(x, y + size, 0);
+
+        Wall.Create(doc, Line.CreateBound(p1, p2), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p2, p3), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p3, p4), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p4, p1), levelId, false);
+    }
+
+    #endregion
+}

--- a/revit-mcp-commandset.Tests/AssemblyInfo.cs
+++ b/revit-mcp-commandset.Tests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using Nice3point.TUnit.Revit.Executors;
+using TUnit.Core.Executors;
+
+[assembly: TestExecutor<RevitThreadExecutor>]

--- a/revit-mcp-commandset.Tests/ColorSplashHandlerTests.cs
+++ b/revit-mcp-commandset.Tests/ColorSplashHandlerTests.cs
@@ -1,0 +1,193 @@
+using Autodesk.Revit.DB;
+using Newtonsoft.Json.Linq;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using RevitMCPCommandSet.Services;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests;
+
+public class ColorSplashHandlerTests : RevitApiTest
+{
+    private static Document _doc = null!;
+    private static string _tempPath = null!;
+#pragma warning disable TUnit0023 // Revit elements are disposed when the document is closed
+    private static ViewPlan _floorPlan = null!;
+#pragma warning restore TUnit0023
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        var doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using (var tx = new Transaction(doc, "Setup Color Splash Test Environment"))
+        {
+            tx.Start();
+
+            var level = Level.Create(doc, 0.0);
+            level.Name = "Color Test Level";
+
+            var floorPlanType = new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewFamilyType))
+                .Cast<ViewFamilyType>()
+                .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+            if (floorPlanType != null)
+            {
+                ViewPlan.Create(doc, floorPlanType.Id, level.Id);
+            }
+
+            // Create walls with different Comments parameter values
+            var wall1 = Wall.Create(doc, Line.CreateBound(new XYZ(0, 0, 0), new XYZ(10, 0, 0)), level.Id, false);
+            var wall2 = Wall.Create(doc, Line.CreateBound(new XYZ(10, 0, 0), new XYZ(20, 0, 0)), level.Id, false);
+            var wall3 = Wall.Create(doc, Line.CreateBound(new XYZ(20, 0, 0), new XYZ(30, 0, 0)), level.Id, false);
+
+            // Set Comments parameter on walls
+            wall1.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set("Group A");
+            wall2.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set("Group A");
+            wall3.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set("Group B");
+
+            tx.Commit();
+        }
+
+        _tempPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.rvt");
+        doc.SaveAs(_tempPath);
+        doc.Close(false);
+        _doc = Application.OpenDocumentFile(_tempPath);
+
+        // Find the floor plan view associated with our level in the reopened document
+        _floorPlan = new FilteredElementCollector(_doc)
+            .OfClass(typeof(ViewPlan))
+            .Cast<ViewPlan>()
+            .First(v => v.ViewType == ViewType.FloorPlan &&
+                        !v.IsTemplate &&
+                        v.GenLevel != null &&
+                        v.GenLevel.Name == "Color Test Level");
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+        try { File.Delete(_tempPath); } catch { }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_WallsByComments_GroupsAndColorsCorrectly()
+    {
+        var handler = new ColorSplashHandler();
+        handler.SetParameters("Walls", "Comments", useGradient: false, customColors: null);
+
+        handler.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result = handler.ColoringResults;
+        await Assert.That((bool)result.success).IsTrue();
+        await Assert.That((int)result.totalElements).IsEqualTo(3);
+        await Assert.That((int)result.coloredGroups).IsEqualTo(2);
+
+        // Verify each group has the correct element count
+        var results = (List<object>)result.results;
+        var groupA = results.Cast<dynamic>().First(r => (string)r.parameterValue == "Group A");
+        var groupB = results.Cast<dynamic>().First(r => (string)r.parameterValue == "Group B");
+        await Assert.That((int)groupA.count).IsEqualTo(2);
+        await Assert.That((int)groupB.count).IsEqualTo(1);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_WithCustomColors_UsesProvidedColors()
+    {
+        var customColors = new JArray
+        {
+            new JObject { ["r"] = 255, ["g"] = 0, ["b"] = 0 },
+            new JObject { ["r"] = 0, ["g"] = 255, ["b"] = 0 }
+        };
+
+        var handler = new ColorSplashHandler();
+        handler.SetParameters("Walls", "Comments", useGradient: false, customColors: customColors);
+
+        handler.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result = handler.ColoringResults;
+        await Assert.That((bool)result.success).IsTrue();
+
+        // Verify the assigned colors match what was requested
+        var results = (List<object>)result.results;
+        var colors = results.Cast<dynamic>().Select(r => r.color).ToList();
+        var firstColor = colors[0];
+        var secondColor = colors[1];
+        await Assert.That((int)firstColor.r).IsEqualTo(255);
+        await Assert.That((int)firstColor.g).IsEqualTo(0);
+        await Assert.That((int)firstColor.b).IsEqualTo(0);
+        await Assert.That((int)secondColor.r).IsEqualTo(0);
+        await Assert.That((int)secondColor.g).IsEqualTo(255);
+        await Assert.That((int)secondColor.b).IsEqualTo(0);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_WithGradient_InterpolatesColors()
+    {
+        var handler = new ColorSplashHandler();
+        handler.SetParameters("Walls", "Comments", useGradient: true, customColors: null);
+
+        handler.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result = handler.ColoringResults;
+        await Assert.That((bool)result.success).IsTrue();
+
+        // Gradient goes blue (0,0,180) → red (180,0,0), so the two groups
+        // should get distinct colors with the first more blue and the last more red
+        var results = (List<object>)result.results;
+        var colors = results.Cast<dynamic>().Select(r => r.color).ToList();
+        var firstColor = colors[0];
+        var lastColor = colors[colors.Count - 1];
+        await Assert.That((int)firstColor.b).IsGreaterThan((int)firstColor.r);
+        await Assert.That((int)lastColor.r).IsGreaterThan((int)lastColor.b);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_InvalidCategory_ReportsError()
+    {
+        var handler = new ColorSplashHandler();
+        handler.SetParameters("NonExistentCategory", "Comments", useGradient: false, customColors: null);
+
+        handler.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result = handler.ColoringResults;
+        await Assert.That((bool)result.success).IsFalse();
+        await Assert.That((string)result.message).Contains("not found");
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_ResultStructure_ContainsExpectedFields()
+    {
+        var handler = new ColorSplashHandler();
+        handler.SetParameters("Walls", "Comments", useGradient: false, customColors: null);
+
+        handler.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result = handler.ColoringResults;
+        await Assert.That((bool)result.success).IsTrue();
+
+        // Verify each result entry has the expected structure
+        var results = (List<object>)result.results;
+        await Assert.That(results.Count).IsEqualTo(2);
+
+        foreach (dynamic entry in results)
+        {
+            await Assert.That((string)entry.parameterValue).IsNotNull();
+            await Assert.That((int)entry.count).IsGreaterThan(0);
+            await Assert.That((int)entry.color.r).IsGreaterThanOrEqualTo(0).And.IsLessThanOrEqualTo(255);
+            await Assert.That((int)entry.color.g).IsGreaterThanOrEqualTo(0).And.IsLessThanOrEqualTo(255);
+            await Assert.That((int)entry.color.b).IsGreaterThanOrEqualTo(0).And.IsLessThanOrEqualTo(255);
+            await Assert.That(((List<string>)entry.elementIds).Count).IsEqualTo((int)entry.count);
+        }
+    }
+}

--- a/revit-mcp-commandset.Tests/DataExtraction/AnalyzeModelStatisticsHandlerTests.cs
+++ b/revit-mcp-commandset.Tests/DataExtraction/AnalyzeModelStatisticsHandlerTests.cs
@@ -1,0 +1,137 @@
+using Autodesk.Revit.DB;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using RevitMCPCommandSet.Services.DataExtraction;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.DataExtraction;
+
+public class AnalyzeModelStatisticsHandlerTests : RevitApiTest
+{
+    private static Document _doc = null!;
+    private static string _tempPath = null!;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        var doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using (var tx = new Transaction(doc, "Setup Statistics Test"))
+        {
+            tx.Start();
+
+            var level = Level.Create(doc, 0.0);
+            level.Name = "Stats Test Level";
+
+            var floorPlanType = new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewFamilyType))
+                .Cast<ViewFamilyType>()
+                .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+            if (floorPlanType != null)
+            {
+                ViewPlan.Create(doc, floorPlanType.Id, level.Id);
+            }
+
+            // Create walls to have some categorized elements
+            Wall.Create(doc, Line.CreateBound(new XYZ(0, 0, 0), new XYZ(10, 0, 0)), level.Id, false);
+            Wall.Create(doc, Line.CreateBound(new XYZ(10, 0, 0), new XYZ(10, 10, 0)), level.Id, false);
+            Wall.Create(doc, Line.CreateBound(new XYZ(10, 10, 0), new XYZ(0, 10, 0)), level.Id, false);
+
+            tx.Commit();
+        }
+
+        _tempPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.rvt");
+        doc.SaveAs(_tempPath);
+        doc.Close(false);
+        _doc = Application.OpenDocumentFile(_tempPath);
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+        try { File.Delete(_tempPath); } catch { }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_BasicModel_ReturnsSuccessfulResult()
+    {
+        var handler = new AnalyzeModelStatisticsHandler();
+        handler.SetParameters(includeDetailedTypes: true);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo).IsNotNull();
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+        await Assert.That(handler.ResultInfo.Message).IsNotNull();
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_CategoriesPopulated_WallsCounted()
+    {
+        var handler = new AnalyzeModelStatisticsHandler();
+        handler.SetParameters(includeDetailedTypes: true);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+        await Assert.That(handler.ResultInfo.TotalElements).IsGreaterThan(0);
+        await Assert.That(handler.ResultInfo.Categories.Count).IsGreaterThan(0);
+
+        // Verify walls category exists with the 3 walls we created
+        var wallCategory = handler.ResultInfo.Categories.FirstOrDefault(c => c.CategoryName == "Walls");
+        await Assert.That(wallCategory).IsNotNull();
+        await Assert.That(wallCategory.ElementCount).IsGreaterThanOrEqualTo(3);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_LevelStatistics_LevelsListed()
+    {
+        var handler = new AnalyzeModelStatisticsHandler();
+        handler.SetParameters(includeDetailedTypes: false);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+        await Assert.That(handler.ResultInfo.Levels.Count).IsGreaterThan(0);
+
+        // Verify our setup level is present
+        var testLevel = handler.ResultInfo.Levels.FirstOrDefault(l => l.LevelName == "Stats Test Level");
+        await Assert.That(testLevel).IsNotNull();
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_ProjectName_MatchesDocument()
+    {
+        var handler = new AnalyzeModelStatisticsHandler();
+        handler.SetParameters(includeDetailedTypes: false);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+        await Assert.That(handler.ResultInfo.ProjectName).IsEqualTo(_doc.Title);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_TaskCompleted_FlagSet()
+    {
+        var handler = new AnalyzeModelStatisticsHandler();
+        handler.SetParameters(includeDetailedTypes: true);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.TaskCompleted).IsTrue();
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+        await Assert.That(handler.ResultInfo.TotalTypes).IsGreaterThan(0);
+        await Assert.That(handler.ResultInfo.TotalViews).IsGreaterThan(0);
+    }
+}

--- a/revit-mcp-commandset.Tests/DataExtraction/ExportRoomDataHandlerTests.cs
+++ b/revit-mcp-commandset.Tests/DataExtraction/ExportRoomDataHandlerTests.cs
@@ -1,0 +1,161 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using RevitMCPCommandSet.Services.DataExtraction;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.DataExtraction;
+
+public class ExportRoomDataHandlerTests : RevitApiTest
+{
+    private static Document _doc = null!;
+    private static string _tempPath = null!;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        var doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using (var tx = new Transaction(doc, "Setup Export Room Data Test"))
+        {
+            tx.Start();
+
+            var level = Level.Create(doc, 0.0);
+            level.Name = "Export Test Level";
+
+            var floorPlanType = new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewFamilyType))
+                .Cast<ViewFamilyType>()
+                .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+            if (floorPlanType != null)
+            {
+                ViewPlan.Create(doc, floorPlanType.Id, level.Id);
+            }
+
+            // Create enclosure and placed room
+            CreateEnclosure(doc, level.Id, 0, 0, 10);
+            var room = doc.Create.NewRoom(level, new UV(5.0, 5.0));
+            if (room != null)
+            {
+                room.get_Parameter(BuiltInParameter.ROOM_NAME)?.Set("Test Room");
+                room.get_Parameter(BuiltInParameter.ROOM_DEPARTMENT)?.Set("Testing");
+            }
+
+            // Create an unplaced room
+            var phases = new FilteredElementCollector(doc)
+                .OfClass(typeof(Phase))
+                .Cast<Phase>()
+                .ToList();
+            if (phases.Count > 0)
+            {
+                doc.Create.NewRoom(phases.First());
+            }
+
+            tx.Commit();
+        }
+
+        _tempPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.rvt");
+        doc.SaveAs(_tempPath);
+        doc.Close(false);
+        _doc = Application.OpenDocumentFile(_tempPath);
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+        try { File.Delete(_tempPath); } catch { }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_PlacedRooms_DataExported()
+    {
+        var handler = new ExportRoomDataHandler();
+        handler.SetParameters(includeUnplacedRooms: false, includeNotEnclosedRooms: false);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo).IsNotNull();
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+        await Assert.That(handler.ResultInfo.TotalRooms).IsGreaterThan(0);
+        await Assert.That(handler.ResultInfo.Rooms.Count).IsGreaterThan(0);
+
+        var room = handler.ResultInfo.Rooms.First();
+        await Assert.That(room.Name).IsEqualTo("Test Room");
+        await Assert.That(room.Number).IsNotNullOrEmpty();
+        await Assert.That(room.Level).IsEqualTo("Export Test Level");
+        await Assert.That(room.Department).IsEqualTo("Testing");
+        await Assert.That(room.Area).IsGreaterThan(0);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_SkipUnplaced_UnplacedRoomsExcluded()
+    {
+        var handler = new ExportRoomDataHandler();
+        handler.SetParameters(includeUnplacedRooms: false, includeNotEnclosedRooms: false);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+
+        // All returned rooms should have area > 0
+        foreach (var room in handler.ResultInfo.Rooms)
+        {
+            await Assert.That(room.Area).IsGreaterThan(0);
+        }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_IncludeUnplaced_AllRoomsReturned()
+    {
+        // Baseline: count placed rooms only
+        var placedOnly = new ExportRoomDataHandler();
+        placedOnly.SetParameters(includeUnplacedRooms: false, includeNotEnclosedRooms: false);
+        placedOnly.RunOnDocument(_doc);
+
+        // Act: count all rooms including unplaced
+        var includeAll = new ExportRoomDataHandler();
+        includeAll.SetParameters(includeUnplacedRooms: true, includeNotEnclosedRooms: true);
+        includeAll.RunOnDocument(_doc);
+
+        await Assert.That(includeAll.ResultInfo.Success).IsTrue();
+        await Assert.That(includeAll.ResultInfo.TotalRooms).IsGreaterThan(placedOnly.ResultInfo.TotalRooms);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_TotalArea_MatchesSumOfRoomAreas()
+    {
+        var handler = new ExportRoomDataHandler();
+        handler.SetParameters(includeUnplacedRooms: false, includeNotEnclosedRooms: false);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+
+        double expectedTotal = handler.ResultInfo.Rooms.Sum(r => r.Area);
+        await Assert.That(handler.ResultInfo.TotalArea).IsEqualTo(expectedTotal).Within(0.001);
+        await Assert.That(handler.ResultInfo.TotalArea).IsGreaterThan(0);
+    }
+
+    private static void CreateEnclosure(Document doc, ElementId levelId, double x, double y, double size)
+    {
+        var p1 = new XYZ(x, y, 0);
+        var p2 = new XYZ(x + size, y, 0);
+        var p3 = new XYZ(x + size, y + size, 0);
+        var p4 = new XYZ(x, y + size, 0);
+
+        Wall.Create(doc, Line.CreateBound(p1, p2), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p2, p3), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p3, p4), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p4, p1), levelId, false);
+    }
+}

--- a/revit-mcp-commandset.Tests/DataExtraction/GetMaterialQuantitiesHandlerTests.cs
+++ b/revit-mcp-commandset.Tests/DataExtraction/GetMaterialQuantitiesHandlerTests.cs
@@ -1,0 +1,132 @@
+using Autodesk.Revit.DB;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using RevitMCPCommandSet.Services.DataExtraction;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.DataExtraction;
+
+public class GetMaterialQuantitiesHandlerTests : RevitApiTest
+{
+    private static Document _doc = null!;
+    private static string _tempPath = null!;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        var doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using (var tx = new Transaction(doc, "Setup Material Quantities Test"))
+        {
+            tx.Start();
+
+            var level = Level.Create(doc, 0.0);
+            level.Name = "Material Test Level";
+
+            // Create walls that will have materials
+            Wall.Create(doc, Line.CreateBound(new XYZ(0, 0, 0), new XYZ(10, 0, 0)), level.Id, false);
+            Wall.Create(doc, Line.CreateBound(new XYZ(10, 0, 0), new XYZ(10, 10, 0)), level.Id, false);
+            Wall.Create(doc, Line.CreateBound(new XYZ(10, 10, 0), new XYZ(0, 10, 0)), level.Id, false);
+
+            tx.Commit();
+        }
+
+        _tempPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.rvt");
+        doc.SaveAs(_tempPath);
+        doc.Close(false);
+        _doc = Application.OpenDocumentFile(_tempPath);
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+        try { File.Delete(_tempPath); } catch { }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_AllCategories_MaterialsFound()
+    {
+        var handler = new GetMaterialQuantitiesHandler();
+        handler.SetParameters(categoryFilters: null, selectedElementsOnly: false);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo).IsNotNull();
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+        await Assert.That(handler.ResultInfo.TotalMaterials).IsGreaterThan(0);
+        await Assert.That(handler.ResultInfo.Materials.Count).IsGreaterThan(0);
+
+        // Verify material names are populated
+        foreach (var material in handler.ResultInfo.Materials)
+        {
+            await Assert.That(material.MaterialName).IsNotNullOrEmpty();
+        }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_FilterByWalls_OnlyWallMaterialsReturned()
+    {
+        var handler = new GetMaterialQuantitiesHandler();
+        handler.SetParameters(
+            categoryFilters: new List<string> { "OST_Walls" },
+            selectedElementsOnly: false);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+        await Assert.That(handler.ResultInfo.TotalMaterials).IsGreaterThan(0);
+
+        // Since setup only creates walls, filtered results should match unfiltered
+        var allHandler = new GetMaterialQuantitiesHandler();
+        allHandler.SetParameters(categoryFilters: null, selectedElementsOnly: false);
+        allHandler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo.TotalMaterials).IsEqualTo(allHandler.ResultInfo.TotalMaterials);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_AreaAndVolume_NonNegative()
+    {
+        var handler = new GetMaterialQuantitiesHandler();
+        handler.SetParameters(categoryFilters: null, selectedElementsOnly: false);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+        await Assert.That(handler.ResultInfo.TotalArea).IsGreaterThanOrEqualTo(0);
+        await Assert.That(handler.ResultInfo.TotalVolume).IsGreaterThanOrEqualTo(0);
+
+        foreach (var material in handler.ResultInfo.Materials)
+        {
+            await Assert.That(material.Area).IsGreaterThanOrEqualTo(0);
+            await Assert.That(material.Volume).IsGreaterThanOrEqualTo(0);
+        }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_ElementCountPerMaterial_TracksUniqueElements()
+    {
+        var handler = new GetMaterialQuantitiesHandler();
+        handler.SetParameters(categoryFilters: null, selectedElementsOnly: false);
+
+        handler.RunOnDocument(_doc);
+
+        await Assert.That(handler.ResultInfo.Success).IsTrue();
+
+        foreach (var material in handler.ResultInfo.Materials)
+        {
+            await Assert.That(material.ElementCount).IsGreaterThan(0);
+            await Assert.That(material.ElementIds.Count).IsEqualTo(material.ElementCount);
+            // Verify element IDs are unique
+            await Assert.That(material.ElementIds.Distinct().Count()).IsEqualTo(material.ElementIds.Count);
+        }
+    }
+}

--- a/revit-mcp-commandset.Tests/RevitMCPCommandSet.Tests.csproj
+++ b/revit-mcp-commandset.Tests/RevitMCPCommandSet.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Nice3point.Revit.Sdk/6.1.0">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+    <Configurations>Debug.R25;Debug.R26</Configurations>
+    <Configurations>$(Configurations);Release.R25;Release.R26</Configurations>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*" />
+    <PackageReference Include="Nice3point.TUnit.Revit" Version="$(RevitVersion).*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\revit-mcp-commandset\RevitMCPCommandSet.csproj" />
+  </ItemGroup>
+</Project>

--- a/revit-mcp-commandset.Tests/TagRoomsHandlerTests.cs
+++ b/revit-mcp-commandset.Tests/TagRoomsHandlerTests.cs
@@ -1,0 +1,211 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using RevitMCPCommandSet.Services;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests;
+
+public class TagRoomsHandlerTests : RevitApiTest
+{
+    private static Document _doc = null!;
+    private static string _tempPath = null!;
+#pragma warning disable TUnit0023 // Revit elements are disposed when the document is closed
+    private static ViewPlan _floorPlan = null!;
+#pragma warning restore TUnit0023
+    private static Room _room1 = null!;
+    private static Room _room2 = null!;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        // Use default template which includes room tag annotation families
+        var doc = Application.NewProjectDocument(Application.DefaultProjectTemplate);
+
+        // Use the first level from the template (Level 1)
+        var level = new FilteredElementCollector(doc)
+            .OfClass(typeof(Level))
+            .Cast<Level>()
+            .OrderBy(l => l.Elevation)
+            .First();
+
+        string levelName = level.Name;
+
+        using (var tx = new Transaction(doc, "Setup Tag Test Environment"))
+        {
+            tx.Start();
+
+            // Create primary enclosure (0,0)-(10,10) with a room
+            CreateEnclosure(doc, level.Id, 0, 0, 10);
+            _room1 = doc.Create.NewRoom(level, new UV(5.0, 5.0));
+
+            // Create secondary enclosure (20,0)-(30,10) with another room
+            CreateEnclosure(doc, level.Id, 20, 0, 10);
+            _room2 = doc.Create.NewRoom(level, new UV(25.0, 5.0));
+
+            tx.Commit();
+        }
+
+        _tempPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.rvt");
+        doc.SaveAs(_tempPath);
+        doc.Close(false);
+        _doc = Application.OpenDocumentFile(_tempPath);
+
+        // Find the floor plan view for our level in the reopened document
+        _floorPlan = new FilteredElementCollector(_doc)
+            .OfClass(typeof(ViewPlan))
+            .Cast<ViewPlan>()
+            .First(v => v.ViewType == ViewType.FloorPlan &&
+                        !v.IsTemplate &&
+                        v.GenLevel != null &&
+                        v.GenLevel.Name == levelName);
+
+        // Re-find rooms in the reopened document
+        var rooms = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Rooms)
+            .WhereElementIsNotElementType()
+            .Cast<Room>()
+            .Where(r => r.Area > 0)
+            .ToList();
+
+        _room1 = rooms[0];
+        _room2 = rooms[1];
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+        try { File.Delete(_tempPath); } catch { }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_AllRooms_TagsCreatedSuccessfully()
+    {
+        var handler = new TagRoomsHandler();
+        handler.SetParameters(useLeader: false, tagTypeId: null);
+
+        handler.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result = handler.TaggingResults;
+        await Assert.That((bool)result.success).IsTrue();
+        await Assert.That((int)result.totalRooms).IsEqualTo(2);
+        await Assert.That((int)result.taggedRooms).IsGreaterThan(0);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_WithLeader_TagsHaveLeaders()
+    {
+        // Clear any existing room tags so this test doesn't depend on execution order
+        using (var tx = new Transaction(_doc, "Clear tags for test"))
+        {
+            tx.Start();
+            var existingTags = new FilteredElementCollector(_doc, _floorPlan.Id)
+                .OfCategory(BuiltInCategory.OST_RoomTags)
+                .WhereElementIsNotElementType()
+                .ToElementIds();
+            foreach (var id in existingTags)
+                _doc.Delete(id);
+            tx.Commit();
+        }
+
+        var handler = new TagRoomsHandler();
+        handler.SetParameters(useLeader: true, tagTypeId: null);
+
+        handler.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result = handler.TaggingResults;
+        await Assert.That((bool)result.success).IsTrue();
+        await Assert.That((int)result.taggedRooms).IsEqualTo(2);
+
+        // Verify the tags actually have leaders set
+        var tags = new FilteredElementCollector(_doc, _floorPlan.Id)
+            .OfCategory(BuiltInCategory.OST_RoomTags)
+            .WhereElementIsNotElementType()
+            .Cast<RoomTag>()
+            .ToList();
+        await Assert.That(tags.Count).IsEqualTo(2);
+        foreach (var tag in tags)
+        {
+            await Assert.That(tag.HasLeader).IsTrue();
+        }
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_SpecificRoomIds_OnlyThoseRoomsTagged()
+    {
+        await Assert.That(_room1).IsNotNull();
+
+        var handler = new TagRoomsHandler();
+        handler.SetParameters(
+            useLeader: false,
+            tagTypeId: null,
+            roomIds: new List<int> { (int)_room1.Id.Value });
+
+        handler.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result = handler.TaggingResults;
+        await Assert.That((bool)result.success).IsTrue();
+        // Only the one specified room should be processed
+        int tagged = (int)result.taggedRooms;
+        int skipped = (int)result.skippedCount;
+        await Assert.That(tagged + skipped).IsEqualTo(1);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_AlreadyTaggedRooms_SkippedCorrectly()
+    {
+        // First call: tag all rooms
+        var handler1 = new TagRoomsHandler();
+        handler1.SetParameters(useLeader: false, tagTypeId: null);
+        handler1.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result1 = handler1.TaggingResults;
+        await Assert.That((bool)result1.success).IsTrue();
+
+        // Second call: same rooms should be skipped
+        var handler2 = new TagRoomsHandler();
+        handler2.SetParameters(useLeader: false, tagTypeId: null);
+        handler2.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result2 = handler2.TaggingResults;
+        await Assert.That((bool)result2.success).IsTrue();
+        // Skipped count should be > 0 since rooms already have tags
+        await Assert.That((int)result2.skippedCount).IsGreaterThan(0);
+    }
+
+    [Test]
+    [TestExecutor<RevitThreadExecutor>]
+    public async Task Execute_ResultContainsRoomInfo_MessagePopulated()
+    {
+        var handler = new TagRoomsHandler();
+        handler.SetParameters(useLeader: false, tagTypeId: null);
+
+        handler.RunOnDocument(_doc, _floorPlan);
+
+        dynamic result = handler.TaggingResults;
+        await Assert.That((string)result.message).IsNotNull();
+        await Assert.That((string)result.message).IsNotEmpty();
+    }
+
+    private static void CreateEnclosure(Document doc, ElementId levelId, double x, double y, double size)
+    {
+        var p1 = new XYZ(x, y, 0);
+        var p2 = new XYZ(x + size, y, 0);
+        var p3 = new XYZ(x + size, y + size, 0);
+        var p4 = new XYZ(x, y + size, 0);
+
+        Wall.Create(doc, Line.CreateBound(p1, p2), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p2, p3), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p3, p4), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p4, p1), levelId, false);
+    }
+}

--- a/revit-mcp-commandset.sln
+++ b/revit-mcp-commandset.sln
@@ -1,9 +1,11 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.14.35906.104
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitMCPCommandSet", "revit-mcp-commandset\RevitMCPCommandSet.csproj", "{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitMCPCommandSet.Tests", "revit-mcp-commandset.Tests\RevitMCPCommandSet.Tests.csproj", "{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,12 +15,18 @@ Global
 		Debug R23|Any CPU = Debug R23|Any CPU
 		Debug R24|Any CPU = Debug R24|Any CPU
 		Debug R25|Any CPU = Debug R25|Any CPU
+		Debug R26|Any CPU = Debug R26|Any CPU
+		Debug.R25|Any CPU = Debug.R25|Any CPU
+		Debug.R26|Any CPU = Debug.R26|Any CPU
 		Release R20|Any CPU = Release R20|Any CPU
 		Release R21|Any CPU = Release R21|Any CPU
 		Release R22|Any CPU = Release R22|Any CPU
 		Release R23|Any CPU = Release R23|Any CPU
 		Release R24|Any CPU = Release R24|Any CPU
 		Release R25|Any CPU = Release R25|Any CPU
+		Release R26|Any CPU = Release R26|Any CPU
+		Release.R25|Any CPU = Release.R25|Any CPU
+		Release.R26|Any CPU = Release.R26|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug R20|Any CPU.ActiveCfg = Debug R20|Any CPU
@@ -33,6 +41,12 @@ Global
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug R24|Any CPU.Build.0 = Debug R24|Any CPU
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug R25|Any CPU.ActiveCfg = Debug R25|Any CPU
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug R25|Any CPU.Build.0 = Debug R25|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug R26|Any CPU.ActiveCfg = Debug R26|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug R26|Any CPU.Build.0 = Debug R26|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug.R25|Any CPU.ActiveCfg = Debug R25|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug.R25|Any CPU.Build.0 = Debug R25|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug.R26|Any CPU.ActiveCfg = Debug R26|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Debug.R26|Any CPU.Build.0 = Debug R26|Any CPU
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R20|Any CPU.ActiveCfg = Release R20|Any CPU
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R20|Any CPU.Build.0 = Release R20|Any CPU
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R21|Any CPU.ActiveCfg = Release R21|Any CPU
@@ -45,6 +59,38 @@ Global
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R24|Any CPU.Build.0 = Release R24|Any CPU
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R25|Any CPU.ActiveCfg = Release R25|Any CPU
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R25|Any CPU.Build.0 = Release R25|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R26|Any CPU.ActiveCfg = Release R26|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R26|Any CPU.Build.0 = Release R26|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release.R25|Any CPU.ActiveCfg = Release R25|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release.R25|Any CPU.Build.0 = Release R25|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release.R26|Any CPU.ActiveCfg = Release R26|Any CPU
+		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release.R26|Any CPU.Build.0 = Release R26|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug R20|Any CPU.ActiveCfg = Debug.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug R21|Any CPU.ActiveCfg = Debug.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug R22|Any CPU.ActiveCfg = Debug.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug R23|Any CPU.ActiveCfg = Debug.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug R24|Any CPU.ActiveCfg = Debug.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug R25|Any CPU.ActiveCfg = Debug.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug R25|Any CPU.Build.0 = Debug.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug R26|Any CPU.ActiveCfg = Debug.R26|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug R26|Any CPU.Build.0 = Debug.R26|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug.R25|Any CPU.ActiveCfg = Debug.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug.R25|Any CPU.Build.0 = Debug.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug.R26|Any CPU.ActiveCfg = Debug.R26|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Debug.R26|Any CPU.Build.0 = Debug.R26|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release R20|Any CPU.ActiveCfg = Release.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release R21|Any CPU.ActiveCfg = Release.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release R22|Any CPU.ActiveCfg = Release.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release R23|Any CPU.ActiveCfg = Release.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release R24|Any CPU.ActiveCfg = Release.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release R25|Any CPU.ActiveCfg = Release.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release R25|Any CPU.Build.0 = Release.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release R26|Any CPU.ActiveCfg = Release.R26|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release R26|Any CPU.Build.0 = Release.R26|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release.R25|Any CPU.ActiveCfg = Release.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release.R25|Any CPU.Build.0 = Release.R25|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release.R26|Any CPU.ActiveCfg = Release.R26|Any CPU
+		{B5F1E2D3-4A6C-8E9F-0123-456789ABCDEF}.Release.R26|Any CPU.Build.0 = Release.R26|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/revit-mcp-commandset/Commands/Architecture/CreateLevelCommand.cs
+++ b/revit-mcp-commandset/Commands/Architecture/CreateLevelCommand.cs
@@ -1,0 +1,59 @@
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+using RevitMCPSDK.API.Base;
+using RevitMCPCommandSet.Services.Architecture;
+using LevelCreationInfo = RevitMCPCommandSet.Models.Architecture.LevelInfo;
+
+namespace RevitMCPCommandSet.Commands.Architecture
+{
+    /// <summary>
+    /// Command to create levels in Revit with automatic floor plan view generation
+    /// </summary>
+    public class CreateLevelCommand : ExternalEventCommandBase
+    {
+        private CreateLevelEventHandler _handler => (CreateLevelEventHandler)Handler;
+
+        /// <summary>
+        /// Command name - must match the MCP tool name
+        /// </summary>
+        public override string CommandName => "create_level";
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="uiApp">Revit UIApplication</param>
+        public CreateLevelCommand(UIApplication uiApp)
+            : base(new CreateLevelEventHandler(), uiApp)
+        {
+        }
+
+        public override object Execute(JObject parameters, string requestId)
+        {
+            try
+            {
+                List<LevelCreationInfo> data = new List<LevelCreationInfo>();
+                // Parse parameters
+                data = parameters["data"].ToObject<List<LevelCreationInfo>>();
+                if (data == null || data.Count == 0)
+                    throw new ArgumentNullException(nameof(data), "No level data provided");
+
+                // Set parameters for the event handler
+                _handler.SetParameters(data);
+
+                // Trigger external event and wait for completion
+                if (RaiseAndWaitForCompletion(15000)) // 15 second timeout
+                {
+                    return _handler.Result;
+                }
+                else
+                {
+                    throw new TimeoutException("Create level operation timed out");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to create level: {ex.Message}");
+            }
+        }
+    }
+}

--- a/revit-mcp-commandset/Commands/Architecture/CreateLevelCommand.cs
+++ b/revit-mcp-commandset/Commands/Architecture/CreateLevelCommand.cs
@@ -31,9 +31,8 @@ namespace RevitMCPCommandSet.Commands.Architecture
         {
             try
             {
-                List<LevelCreationInfo> data = new List<LevelCreationInfo>();
                 // Parse parameters
-                data = parameters["data"].ToObject<List<LevelCreationInfo>>();
+                List<LevelCreationInfo> data = parameters["data"].ToObject<List<LevelCreationInfo>>();
                 if (data == null || data.Count == 0)
                     throw new ArgumentNullException(nameof(data), "No level data provided");
 

--- a/revit-mcp-commandset/Commands/Architecture/CreateRoomCommand.cs
+++ b/revit-mcp-commandset/Commands/Architecture/CreateRoomCommand.cs
@@ -1,0 +1,59 @@
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+using RevitMCPSDK.API.Base;
+using RevitMCPCommandSet.Models.Architecture;
+using RevitMCPCommandSet.Services.Architecture;
+
+namespace RevitMCPCommandSet.Commands.Architecture
+{
+    /// <summary>
+    /// Command to create and place rooms in Revit
+    /// </summary>
+    public class CreateRoomCommand : ExternalEventCommandBase
+    {
+        private CreateRoomEventHandler _handler => (CreateRoomEventHandler)Handler;
+
+        /// <summary>
+        /// Command name - must match the MCP tool name
+        /// </summary>
+        public override string CommandName => "create_room";
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="uiApp">Revit UIApplication</param>
+        public CreateRoomCommand(UIApplication uiApp)
+            : base(new CreateRoomEventHandler(), uiApp)
+        {
+        }
+
+        public override object Execute(JObject parameters, string requestId)
+        {
+            try
+            {
+                List<RoomCreationInfo> data = new List<RoomCreationInfo>();
+                // Parse parameters
+                data = parameters["data"].ToObject<List<RoomCreationInfo>>();
+                if (data == null)
+                    throw new ArgumentNullException(nameof(data), "No room data provided");
+
+                // Set parameters for the event handler
+                _handler.SetParameters(data);
+
+                // Trigger external event and wait for completion
+                if (RaiseAndWaitForCompletion(15000)) // 15 second timeout
+                {
+                    return _handler.Result;
+                }
+                else
+                {
+                    throw new TimeoutException("Create room operation timed out");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to create room: {ex.Message}");
+            }
+        }
+    }
+}

--- a/revit-mcp-commandset/Commands/Architecture/CreateRoomCommand.cs
+++ b/revit-mcp-commandset/Commands/Architecture/CreateRoomCommand.cs
@@ -31,9 +31,8 @@ namespace RevitMCPCommandSet.Commands.Architecture
         {
             try
             {
-                List<RoomCreationInfo> data = new List<RoomCreationInfo>();
                 // Parse parameters
-                data = parameters["data"].ToObject<List<RoomCreationInfo>>();
+                List<RoomCreationInfo> data = parameters["data"].ToObject<List<RoomCreationInfo>>();
                 if (data == null)
                     throw new ArgumentNullException(nameof(data), "No room data provided");
 

--- a/revit-mcp-commandset/Commands/Delete/DeleteElementCommand.cs
+++ b/revit-mcp-commandset/Commands/Delete/DeleteElementCommand.cs
@@ -1,63 +1,56 @@
-﻿//using Autodesk.Revit.UI;
-//using Newtonsoft.Json.Linq;
-//using RevitMCPCommandSet.Services;
-//using RevitMCPSDK.API.Base;
-//using RevitMCPSDK.API.Models;
-//using RevitMCPSDK.Exceptions;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+using RevitMCPCommandSet.Services;
+using RevitMCPSDK.API.Base;
 
-//namespace RevitMCPCommandSet.Commands.Delete
-//{
-//    public class DeleteElementCommand : ExternalEventCommandBase
-//    {
-//        private DeleteElementEventHandler _handler => (DeleteElementEventHandler)Handler;
-//        public override string CommandName => "delete_element";
-//        public DeleteElementCommand(UIApplication uiApp)
-//            : base(new DeleteElementEventHandler(), uiApp)
-//        {
-//        }
-//        public override object Execute(JObject parameters, string requestId)
-//        {
-//            try
-//            {
-//                // 解析数组参数
-//                var elementIds = parameters?["elementIds"]?.ToObject<string[]>();
-//                if (elementIds == null || elementIds.Length == 0)
-//                {
-//                    throw new CommandExecutionException(
-//                        "元素ID列表不能为空",
-//                        JsonRPCErrorCodes.InvalidParams);
-//                }
-//                // 设置要删除的元素ID数组
-//                _handler.ElementIds = elementIds;
-//                // 触发外部事件并等待完成
-//                if (RaiseAndWaitForCompletion(15000))
-//                {
-//                    if (_handler.IsSuccess)
-//                    {
-//                        return CommandResult.CreateSuccess(new { deleted = true, count = _handler.DeletedCount });
-//                    }
-//                    else
-//                    {
-//                        throw new CommandExecutionException(
-//                            "删除元素失败",
-//                            JsonRPCErrorCodes.ElementDeletionFailed);
-//                    }
-//                }
-//                else
-//                {
-//                    throw CreateTimeoutException(CommandName);
-//                }
-//            }
-//            catch (CommandExecutionException)
-//            {
-//                throw;
-//            }
-//            catch (Exception ex)
-//            {
-//                throw new CommandExecutionException(
-//                    $"删除元素失败: {ex.Message}",
-//                    JsonRPCErrorCodes.InternalError);
-//            }
-//        }
-//    }
-//}
+namespace RevitMCPCommandSet.Commands.Delete
+{
+    public class DeleteElementCommand : ExternalEventCommandBase
+    {
+        private DeleteElementEventHandler _handler => (DeleteElementEventHandler)Handler;
+
+        public override string CommandName => "delete_element";
+
+        public DeleteElementCommand(UIApplication uiApp)
+            : base(new DeleteElementEventHandler(), uiApp)
+        {
+        }
+
+        public override object Execute(JObject parameters, string requestId)
+        {
+            try
+            {
+                // 解析数组参数
+                var elementIds = parameters?["elementIds"]?.ToObject<string[]>();
+                if (elementIds == null || elementIds.Length == 0)
+                {
+                    throw new ArgumentException("元素ID列表不能为空");
+                }
+
+                // 设置要删除的元素ID数组
+                _handler.ElementIds = elementIds;
+
+                // 触发外部事件并等待完成
+                if (RaiseAndWaitForCompletion(15000))
+                {
+                    if (_handler.IsSuccess)
+                    {
+                        return new { deleted = true, count = _handler.DeletedCount };
+                    }
+                    else
+                    {
+                        throw new Exception("删除元素失败");
+                    }
+                }
+                else
+                {
+                    throw new TimeoutException("删除元素操作超时");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"删除元素失败: {ex.Message}");
+            }
+        }
+    }
+}

--- a/revit-mcp-commandset/Commands/TagRoomsCommand.cs
+++ b/revit-mcp-commandset/Commands/TagRoomsCommand.cs
@@ -1,0 +1,71 @@
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+using RevitMCPCommandSet.Services;
+using RevitMCPSDK.API.Base;
+
+namespace RevitMCPCommandSet.Commands
+{
+    /// <summary>
+    /// Command to create tags for rooms in the current view
+    /// </summary>
+    public class TagRoomsCommand : ExternalEventCommandBase
+    {
+        private TagRoomsEventHandler _handler => (TagRoomsEventHandler)Handler;
+
+        /// <summary>
+        /// Command name - must match the MCP tool command name
+        /// </summary>
+        public override string CommandName => "tag_rooms";
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="uiApp">Revit UIApplication</param>
+        public TagRoomsCommand(UIApplication uiApp)
+            : base(new TagRoomsEventHandler(), uiApp)
+        {
+        }
+
+        public override object Execute(JObject parameters, string requestId)
+        {
+            try
+            {
+                // Parse parameters
+                bool useLeader = false;
+                if (parameters["useLeader"] != null)
+                {
+                    useLeader = parameters["useLeader"].ToObject<bool>();
+                }
+
+                string tagTypeId = null;
+                if (parameters["tagTypeId"] != null)
+                {
+                    tagTypeId = parameters["tagTypeId"].ToString();
+                }
+
+                List<int> roomIds = null;
+                if (parameters["roomIds"] != null)
+                {
+                    roomIds = parameters["roomIds"].ToObject<List<int>>();
+                }
+
+                // Set parameters for the event handler
+                _handler.SetParameters(useLeader, tagTypeId, roomIds);
+
+                // Trigger external event and wait for completion
+                if (RaiseAndWaitForCompletion(15000)) // 15 second timeout
+                {
+                    return _handler.TaggingResults;
+                }
+                else
+                {
+                    throw new TimeoutException("Tag rooms operation timed out");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to tag rooms: {ex.Message}");
+            }
+        }
+    }
+}

--- a/revit-mcp-commandset/Commands/TagWallsCommand.cs
+++ b/revit-mcp-commandset/Commands/TagWallsCommand.cs
@@ -12,7 +12,7 @@ namespace RevitMCPCommandSet.Commands
         /// <summary>
         /// 命令名称
         /// </summary>
-        public override string CommandName => "tag_all_walls";
+        public override string CommandName => "tag_walls";
 
         /// <summary>
         /// 构造函数

--- a/revit-mcp-commandset/Commands/Test/SayHelloCommand.cs
+++ b/revit-mcp-commandset/Commands/Test/SayHelloCommand.cs
@@ -1,0 +1,47 @@
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+using RevitMCPSDK.API.Base;
+using RevitMCPCommandSet.Services;
+
+namespace RevitMCPCommandSet.Commands.Test
+{
+    public class SayHelloCommand : ExternalEventCommandBase
+    {
+        private SayHelloEventHandler _handler => (SayHelloEventHandler)Handler;
+
+        public override string CommandName => "say_hello";
+
+        public SayHelloCommand(UIApplication uiApp)
+            : base(new SayHelloEventHandler(), uiApp)
+        {
+        }
+
+        public override object Execute(JObject parameters, string requestId)
+        {
+            try
+            {
+                // Parse optional message parameter
+                string message = "Hello MCP!";
+                if (parameters?["message"] != null)
+                {
+                    message = parameters["message"].ToString();
+                }
+
+                _handler.Message = message;
+
+                if (RaiseAndWaitForCompletion(15000))
+                {
+                    return new { success = true, message = message };
+                }
+                else
+                {
+                    throw new TimeoutException("Say hello operation timed out");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Say hello failed: {ex.Message}");
+            }
+        }
+    }
+}

--- a/revit-mcp-commandset/Models/Architecture/LevelInfo.cs
+++ b/revit-mcp-commandset/Models/Architecture/LevelInfo.cs
@@ -80,4 +80,16 @@ public class LevelInfo
     /// </summary>
     [JsonProperty("viewElevationOffset")]
     public double ViewElevationOffset { get; set; }
+
+    /// <summary>
+    ///     Whether to create a floor plan view for this level (default: true)
+    /// </summary>
+    [JsonProperty("createFloorPlan")]
+    public bool CreateFloorPlan { get; set; } = true;
+
+    /// <summary>
+    ///     Whether to create a ceiling plan view for this level (default: true)
+    /// </summary>
+    [JsonProperty("createCeilingPlan")]
+    public bool CreateCeilingPlan { get; set; } = true;
 }

--- a/revit-mcp-commandset/Models/Architecture/RoomCreationInfo.cs
+++ b/revit-mcp-commandset/Models/Architecture/RoomCreationInfo.cs
@@ -83,6 +83,36 @@ public class RoomCreationInfo
     public int PhaseId { get; set; }
 
     /// <summary>
+    ///     Upper limit level ID
+    /// </summary>
+    [JsonProperty("upperLimitId")]
+    public int UpperLimitId { get; set; }
+
+    /// <summary>
+    ///     Offset from upper limit (mm)
+    /// </summary>
+    [JsonProperty("limitOffset")]
+    public double LimitOffset { get; set; }
+
+    /// <summary>
+    ///     Offset from base level (mm)
+    /// </summary>
+    [JsonProperty("baseOffset")]
+    public double BaseOffset { get; set; }
+
+    /// <summary>
+    ///     Department the room belongs to
+    /// </summary>
+    [JsonProperty("department")]
+    public string Department { get; set; }
+
+    /// <summary>
+    ///     Comments for the room
+    /// </summary>
+    [JsonProperty("comments")]
+    public string Comments { get; set; }
+
+    /// <summary>
     ///     Additional options
     /// </summary>
     [JsonProperty("options")]

--- a/revit-mcp-commandset/Models/Common/PointElement.cs
+++ b/revit-mcp-commandset/Models/Common/PointElement.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace RevitMCPCommandSet.Models.Common;
 

--- a/revit-mcp-commandset/RevitMCPCommandSet.csproj
+++ b/revit-mcp-commandset/RevitMCPCommandSet.csproj
@@ -51,6 +51,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="RevitMCPCommandSet.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Nice3point.Revit.Build.Tasks" Version="2.*" />
         <PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*" />

--- a/revit-mcp-commandset/RevitMCPCommandSet.csproj
+++ b/revit-mcp-commandset/RevitMCPCommandSet.csproj
@@ -6,8 +6,8 @@
         <PlatformTarget>x64</PlatformTarget>
         <ImplicitUsings>true</ImplicitUsings>
         <PublishAddinFiles>true</PublishAddinFiles>
-        <Configurations>Debug R20;Debug R21;Debug R22;Debug R23;Debug R24;Debug R25</Configurations>
-        <Configurations>$(Configurations);Release R20;Release R21;Release R22;Release R23;Release R24;Release R25</Configurations>
+        <Configurations>Debug R20;Debug R21;Debug R22;Debug R23;Debug R24;Debug R25;Debug R26</Configurations>
+        <Configurations>$(Configurations);Release R20;Release R21;Release R22;Release R23;Release R24;Release R25;Release R26</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(Configuration.Contains('R20'))">
@@ -32,6 +32,10 @@
     </PropertyGroup>
     <PropertyGroup Condition="$(Configuration.Contains('R25'))">
         <RevitVersion>2025</RevitVersion>
+        <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(Configuration.Contains('R26'))">
+        <RevitVersion>2026</RevitVersion>
         <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     </PropertyGroup>
 

--- a/revit-mcp-commandset/RevitMCPCommandSet.csproj
+++ b/revit-mcp-commandset/RevitMCPCommandSet.csproj
@@ -21,22 +21,27 @@
     <PropertyGroup Condition="$(Configuration.Contains('R22'))">
         <RevitVersion>2022</RevitVersion>
         <TargetFramework>net48</TargetFramework>
+        <DefineConstants>$(DefineConstants);REVIT2022_OR_GREATER</DefineConstants>
     </PropertyGroup>
     <PropertyGroup Condition="$(Configuration.Contains('R23'))">
         <RevitVersion>2023</RevitVersion>
         <TargetFramework>net48</TargetFramework>
+        <DefineConstants>$(DefineConstants);REVIT2022_OR_GREATER;REVIT2023_OR_GREATER</DefineConstants>
     </PropertyGroup>
     <PropertyGroup Condition="$(Configuration.Contains('R24'))">
         <RevitVersion>2024</RevitVersion>
         <TargetFramework>net48</TargetFramework>
+        <DefineConstants>$(DefineConstants);REVIT2022_OR_GREATER;REVIT2023_OR_GREATER;REVIT2024_OR_GREATER</DefineConstants>
     </PropertyGroup>
     <PropertyGroup Condition="$(Configuration.Contains('R25'))">
         <RevitVersion>2025</RevitVersion>
         <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+        <DefineConstants>$(DefineConstants);REVIT2022_OR_GREATER;REVIT2023_OR_GREATER;REVIT2024_OR_GREATER</DefineConstants>
     </PropertyGroup>
     <PropertyGroup Condition="$(Configuration.Contains('R26'))">
         <RevitVersion>2026</RevitVersion>
         <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+        <DefineConstants>$(DefineConstants);REVIT2022_OR_GREATER;REVIT2023_OR_GREATER;REVIT2024_OR_GREATER</DefineConstants>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/revit-mcp-commandset/RevitMCPCommandSet.csproj
+++ b/revit-mcp-commandset/RevitMCPCommandSet.csproj
@@ -64,7 +64,7 @@
 		<PackageReference Include="RevitMCPSDK" Version="$(RevitVersion).*" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
       <Reference Include="System.Net.Http" />
     </ItemGroup>
 

--- a/revit-mcp-commandset/Services/AIElementFilterEventHandler.cs
+++ b/revit-mcp-commandset/Services/AIElementFilterEventHandler.cs
@@ -386,7 +386,7 @@ namespace RevitMCPCommandSet.Services
 
                 ElementInstanceInfo elementInfo = new ElementInstanceInfo();        //创建存储元素完整信息的自定义类
                 // ID
-                elementInfo.Id = element.Id.IntegerValue;
+                elementInfo.Id = (int)element.Id.Value;
                 // UniqueId
                 elementInfo.UniqueId = element.UniqueId;
                 // 类型名称
@@ -396,12 +396,12 @@ namespace RevitMCPCommandSet.Services
                 // 类别
                 elementInfo.Category = element.Category.Name;
                 // 内置类别
-                elementInfo.BuiltInCategory = Enum.GetName(typeof(BuiltInCategory), element.Category.Id.IntegerValue);
+                elementInfo.BuiltInCategory = Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value);
                 // 类型Id
-                elementInfo.TypeId = element.GetTypeId().IntegerValue;
+                elementInfo.TypeId = (int)element.GetTypeId().Value;
                 //所属房间Id  
                 if (element is FamilyInstance instance)
-                    elementInfo.RoomId = instance.Room?.Id.IntegerValue ?? -1;
+                    elementInfo.RoomId = (int)(instance.Room?.Id.Value ?? -1);
                 // 标高
                 elementInfo.Level = GetElementLevel(doc, element);
                 // 最大包围盒
@@ -438,7 +438,7 @@ namespace RevitMCPCommandSet.Services
         {
             ElementTypeInfo typeInfo = new ElementTypeInfo();
             // Id
-            typeInfo.Id = elementType.Id.IntegerValue;
+            typeInfo.Id = (int)elementType.Id.Value;
             // UniqueId
             typeInfo.UniqueId = elementType.UniqueId;
             // 类型名称
@@ -448,7 +448,7 @@ namespace RevitMCPCommandSet.Services
             // 类别
             typeInfo.Category = elementType.Category.Name;
             // 内置类别
-            typeInfo.BuiltInCategory = Enum.GetName(typeof(BuiltInCategory), elementType.Category.Id.IntegerValue);
+            typeInfo.BuiltInCategory = Enum.GetName(typeof(BuiltInCategory), (int)elementType.Category.Id.Value);
             // 参数字典
             typeInfo.Parameters = GetDimensionParameters(elementType);
             ParameterInfo thicknessParam = GetThicknessInfo(elementType);      //厚度参数
@@ -470,13 +470,13 @@ namespace RevitMCPCommandSet.Services
                     return null;
                 PositioningElementInfo info = new PositioningElementInfo
                 {
-                    Id = element.Id.IntegerValue,
+                    Id = (int)element.Id.Value,
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.IntegerValue) : null,
+                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
                     ElementClass = element.GetType().Name,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
@@ -525,13 +525,13 @@ namespace RevitMCPCommandSet.Services
                 SpatialElement spatialElement = element as SpatialElement;
                 SpatialElementInfo info = new SpatialElementInfo
                 {
-                    Id = element.Id.IntegerValue,
+                    Id = (int)element.Id.Value,
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.IntegerValue) : null,
+                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
                     ElementClass = element.GetType().Name,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
@@ -588,13 +588,13 @@ namespace RevitMCPCommandSet.Services
 
                 ViewInfo info = new ViewInfo
                 {
-                    Id = element.Id.IntegerValue,
+                    Id = (int)element.Id.Value,
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.IntegerValue) : null,
+                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
                     ElementClass = element.GetType().Name,
                     ViewType = view.ViewType.ToString(),
                     Scale = view.Scale,
@@ -609,7 +609,7 @@ namespace RevitMCPCommandSet.Services
                     Level level = viewPlan.GenLevel;
                     info.AssociatedLevel = new LevelInfo
                     {
-                        Id = level.Id.IntegerValue,
+                        Id = (int)level.Id.Value,
                         Name = level.Name,
                         Height = level.Elevation * 304.8 // 转换为mm
                     };
@@ -624,12 +624,12 @@ namespace RevitMCPCommandSet.Services
                 foreach (UIView uiView in openViews)
                 {
                     // 检查视图是否打开
-                    if (uiView.ViewId.IntegerValue == view.Id.IntegerValue)
+                    if (uiView.ViewId.Value == view.Id.Value)
                     {
                         info.IsOpen = true;
 
                         // 检查视图是否是当前激活的视图
-                        if (uidoc.ActiveView.Id.IntegerValue == view.Id.IntegerValue)
+                        if (uidoc.ActiveView.Id.Value == view.Id.Value)
                         {
                             info.IsActive = true;
                         }
@@ -656,13 +656,13 @@ namespace RevitMCPCommandSet.Services
                     return null;
                 AnnotationInfo info = new AnnotationInfo
                 {
-                    Id = element.Id.IntegerValue,
+                    Id = (int)element.Id.Value,
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.IntegerValue) : null,
+                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
                     ElementClass = element.GetType().Name,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
@@ -733,13 +733,13 @@ namespace RevitMCPCommandSet.Services
                     return null;
                 GroupOrLinkInfo info = new GroupOrLinkInfo
                 {
-                    Id = element.Id.IntegerValue,
+                    Id = (int)element.Id.Value,
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.IntegerValue) : null,
+                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
                     ElementClass = element.GetType().Name,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
@@ -804,13 +804,13 @@ namespace RevitMCPCommandSet.Services
                     return null;
                 ElementBasicInfo basicInfo = new ElementBasicInfo
                 {
-                    Id = element.Id.IntegerValue,
+                    Id = (int)element.Id.Value,
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.IntegerValue) : null,
+                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
                 return basicInfo;
@@ -854,7 +854,7 @@ namespace RevitMCPCommandSet.Services
             }
             else if (elementType is FamilySymbol familySymbol)
             {
-                switch (familySymbol.Category?.Id.IntegerValue)
+                switch ((int?)familySymbol.Category?.Id.Value)
                 {
                     case (int)BuiltInCategory.OST_Doors:
                     case (int)BuiltInCategory.OST_Windows:
@@ -932,7 +932,7 @@ namespace RevitMCPCommandSet.Services
                 {
                     LevelInfo levelInfo = new LevelInfo
                     {
-                        Id = level.Id.IntegerValue,
+                        Id = (int)level.Id.Value,
                         Name = level.Name,
                         Height = level.Elevation * 304.8
                     };

--- a/revit-mcp-commandset/Services/AIElementFilterEventHandler.cs
+++ b/revit-mcp-commandset/Services/AIElementFilterEventHandler.cs
@@ -386,7 +386,7 @@ namespace RevitMCPCommandSet.Services
 
                 ElementInstanceInfo elementInfo = new ElementInstanceInfo();        //创建存储元素完整信息的自定义类
                 // ID
-                elementInfo.Id = (int)element.Id.Value;
+                elementInfo.Id = element.Id.GetIntValue();
                 // UniqueId
                 elementInfo.UniqueId = element.UniqueId;
                 // 类型名称
@@ -396,12 +396,12 @@ namespace RevitMCPCommandSet.Services
                 // 类别
                 elementInfo.Category = element.Category.Name;
                 // 内置类别
-                elementInfo.BuiltInCategory = Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value);
+                elementInfo.BuiltInCategory = Enum.GetName(typeof(BuiltInCategory), element.Category.Id.GetIntValue());
                 // 类型Id
-                elementInfo.TypeId = (int)element.GetTypeId().Value;
+                elementInfo.TypeId = element.GetTypeId().GetIntValue();
                 //所属房间Id  
                 if (element is FamilyInstance instance)
-                    elementInfo.RoomId = (int)(instance.Room?.Id.Value ?? -1);
+                    elementInfo.RoomId = instance.Room?.Id.GetIntValue() ?? -1;
                 // 标高
                 elementInfo.Level = GetElementLevel(doc, element);
                 // 最大包围盒
@@ -438,7 +438,7 @@ namespace RevitMCPCommandSet.Services
         {
             ElementTypeInfo typeInfo = new ElementTypeInfo();
             // Id
-            typeInfo.Id = (int)elementType.Id.Value;
+            typeInfo.Id = elementType.Id.GetIntValue();
             // UniqueId
             typeInfo.UniqueId = elementType.UniqueId;
             // 类型名称
@@ -448,7 +448,7 @@ namespace RevitMCPCommandSet.Services
             // 类别
             typeInfo.Category = elementType.Category.Name;
             // 内置类别
-            typeInfo.BuiltInCategory = Enum.GetName(typeof(BuiltInCategory), (int)elementType.Category.Id.Value);
+            typeInfo.BuiltInCategory = Enum.GetName(typeof(BuiltInCategory), elementType.Category.Id.GetIntValue());
             // 参数字典
             typeInfo.Parameters = GetDimensionParameters(elementType);
             ParameterInfo thicknessParam = GetThicknessInfo(elementType);      //厚度参数
@@ -470,13 +470,13 @@ namespace RevitMCPCommandSet.Services
                     return null;
                 PositioningElementInfo info = new PositioningElementInfo
                 {
-                    Id = (int)element.Id.Value,
+                    Id = element.Id.GetIntValue(),
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
+                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.GetIntValue()) : null,
                     ElementClass = element.GetType().Name,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
@@ -525,13 +525,13 @@ namespace RevitMCPCommandSet.Services
                 SpatialElement spatialElement = element as SpatialElement;
                 SpatialElementInfo info = new SpatialElementInfo
                 {
-                    Id = (int)element.Id.Value,
+                    Id = element.Id.GetIntValue(),
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
+                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.GetIntValue()) : null,
                     ElementClass = element.GetType().Name,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
@@ -588,13 +588,13 @@ namespace RevitMCPCommandSet.Services
 
                 ViewInfo info = new ViewInfo
                 {
-                    Id = (int)element.Id.Value,
+                    Id = element.Id.GetIntValue(),
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
+                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.GetIntValue()) : null,
                     ElementClass = element.GetType().Name,
                     ViewType = view.ViewType.ToString(),
                     Scale = view.Scale,
@@ -609,7 +609,7 @@ namespace RevitMCPCommandSet.Services
                     Level level = viewPlan.GenLevel;
                     info.AssociatedLevel = new LevelInfo
                     {
-                        Id = (int)level.Id.Value,
+                        Id = level.Id.GetIntValue(),
                         Name = level.Name,
                         Height = level.Elevation * 304.8 // 转换为mm
                     };
@@ -624,12 +624,12 @@ namespace RevitMCPCommandSet.Services
                 foreach (UIView uiView in openViews)
                 {
                     // 检查视图是否打开
-                    if (uiView.ViewId.Value == view.Id.Value)
+                    if (uiView.ViewId.GetValue() == view.Id.GetValue())
                     {
                         info.IsOpen = true;
 
                         // 检查视图是否是当前激活的视图
-                        if (uidoc.ActiveView.Id.Value == view.Id.Value)
+                        if (uidoc.ActiveView.Id.GetValue() == view.Id.GetValue())
                         {
                             info.IsActive = true;
                         }
@@ -656,13 +656,13 @@ namespace RevitMCPCommandSet.Services
                     return null;
                 AnnotationInfo info = new AnnotationInfo
                 {
-                    Id = (int)element.Id.Value,
+                    Id = element.Id.GetIntValue(),
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
+                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.GetIntValue()) : null,
                     ElementClass = element.GetType().Name,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
@@ -733,13 +733,13 @@ namespace RevitMCPCommandSet.Services
                     return null;
                 GroupOrLinkInfo info = new GroupOrLinkInfo
                 {
-                    Id = (int)element.Id.Value,
+                    Id = element.Id.GetIntValue(),
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
+                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.GetIntValue()) : null,
                     ElementClass = element.GetType().Name,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
@@ -804,13 +804,13 @@ namespace RevitMCPCommandSet.Services
                     return null;
                 ElementBasicInfo basicInfo = new ElementBasicInfo
                 {
-                    Id = (int)element.Id.Value,
+                    Id = element.Id.GetIntValue(),
                     UniqueId = element.UniqueId,
                     Name = element.Name,
                     FamilyName = element?.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM)?.AsValueString(),
                     Category = element.Category?.Name,
                     BuiltInCategory = element.Category != null ?
-                        Enum.GetName(typeof(BuiltInCategory), (int)element.Category.Id.Value) : null,
+                        Enum.GetName(typeof(BuiltInCategory), element.Category.Id.GetIntValue()) : null,
                     BoundingBox = GetBoundingBoxInfo(element)
                 };
                 return basicInfo;
@@ -854,7 +854,7 @@ namespace RevitMCPCommandSet.Services
             }
             else if (elementType is FamilySymbol familySymbol)
             {
-                switch ((int?)familySymbol.Category?.Id.Value)
+                switch (familySymbol.Category?.Id.GetIntValue())
                 {
                     case (int)BuiltInCategory.OST_Doors:
                     case (int)BuiltInCategory.OST_Windows:
@@ -932,7 +932,7 @@ namespace RevitMCPCommandSet.Services
                 {
                     LevelInfo levelInfo = new LevelInfo
                     {
-                        Id = (int)level.Id.Value,
+                        Id = level.Id.GetIntValue(),
                         Name = level.Name,
                         Height = level.Elevation * 304.8
                     };

--- a/revit-mcp-commandset/Services/AnnotationComponents/CreateDimensionEventHandler.cs
+++ b/revit-mcp-commandset/Services/AnnotationComponents/CreateDimensionEventHandler.cs
@@ -187,7 +187,7 @@ public class CreateDimensionEventHandler : IExternalEventHandler, IWaitableExter
                             // Apply additional parameters
                             ApplyDimensionParameters(dimension, dimInfo);
 
-                            createdDimensionIds.Add(dimension.Id.IntegerValue);
+                            createdDimensionIds.Add((int)dimension.Id.Value);
                         }
 
                         transaction.Commit();

--- a/revit-mcp-commandset/Services/AnnotationComponents/CreateDimensionEventHandler.cs
+++ b/revit-mcp-commandset/Services/AnnotationComponents/CreateDimensionEventHandler.cs
@@ -24,6 +24,7 @@
 using Autodesk.Revit.UI;
 using RevitMCPCommandSet.Models.Annotation;
 using RevitMCPCommandSet.Models.Common;
+using RevitMCPCommandSet.Utils;
 using RevitMCPSDK.API.Interfaces;
 
 namespace RevitMCPCommandSet.Services.AnnotationComponents;
@@ -187,7 +188,7 @@ public class CreateDimensionEventHandler : IExternalEventHandler, IWaitableExter
                             // Apply additional parameters
                             ApplyDimensionParameters(dimension, dimInfo);
 
-                            createdDimensionIds.Add((int)dimension.Id.Value);
+                            createdDimensionIds.Add(dimension.Id.GetIntValue());
                         }
 
                         transaction.Commit();

--- a/revit-mcp-commandset/Services/Architecture/CreateLevelEventHandler.cs
+++ b/revit-mcp-commandset/Services/Architecture/CreateLevelEventHandler.cs
@@ -8,13 +8,12 @@ using LevelCreationInfo = RevitMCPCommandSet.Models.Architecture.LevelInfo;
 namespace RevitMCPCommandSet.Services.Architecture
 {
     /// <summary>
-    /// Event handler for creating levels in Revit
+    /// Business logic for creating levels in Revit.
+    /// This class has no RevitAPIUI dependencies and can be used directly in tests.
     /// </summary>
-    public class CreateLevelEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
+    public class CreateLevelHandler
     {
-        private UIApplication _uiApp;
-        private UIDocument _uiDoc => _uiApp.ActiveUIDocument;
-        private Document _doc => _uiDoc.Document;
+        private Document _doc;
 
         /// <summary>
         /// Event wait object for synchronization
@@ -40,10 +39,9 @@ namespace RevitMCPCommandSet.Services.Architecture
             _resetEvent.Reset();
         }
 
-        public void Execute(UIApplication uiapp)
+        public void RunOnDocument(Document doc)
         {
-            _uiApp = uiapp;
-
+            _doc = doc;
             try
             {
                 var createdLevels = new List<LevelResultInfo>();
@@ -240,6 +238,17 @@ namespace RevitMCPCommandSet.Services.Architecture
         public bool WaitForCompletion(int timeoutMilliseconds = 10000)
         {
             return _resetEvent.WaitOne(timeoutMilliseconds);
+        }
+    }
+
+    /// <summary>
+    /// Event handler for creating levels in Revit
+    /// </summary>
+    public class CreateLevelEventHandler : CreateLevelHandler, IExternalEventHandler, IWaitableExternalEventHandler
+    {
+        public void Execute(UIApplication uiapp)
+        {
+            RunOnDocument(uiapp.ActiveUIDocument.Document);
         }
 
         /// <summary>

--- a/revit-mcp-commandset/Services/Architecture/CreateLevelEventHandler.cs
+++ b/revit-mcp-commandset/Services/Architecture/CreateLevelEventHandler.cs
@@ -1,0 +1,274 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using RevitMCPCommandSet.Models.Common;
+using RevitMCPSDK.API.Interfaces;
+using LevelCreationInfo = RevitMCPCommandSet.Models.Architecture.LevelInfo;
+
+namespace RevitMCPCommandSet.Services.Architecture
+{
+    /// <summary>
+    /// Event handler for creating levels in Revit
+    /// </summary>
+    public class CreateLevelEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
+    {
+        private UIApplication _uiApp;
+        private UIDocument _uiDoc => _uiApp.ActiveUIDocument;
+        private Document _doc => _uiDoc.Document;
+
+        /// <summary>
+        /// Event wait object for synchronization
+        /// </summary>
+        private readonly ManualResetEvent _resetEvent = new ManualResetEvent(false);
+
+        /// <summary>
+        /// Level creation data (input)
+        /// </summary>
+        public List<LevelCreationInfo> LevelData { get; private set; }
+
+        /// <summary>
+        /// Execution result (output)
+        /// </summary>
+        public AIResult<List<LevelResultInfo>> Result { get; private set; }
+
+        /// <summary>
+        /// Set the level creation parameters
+        /// </summary>
+        public void SetParameters(List<LevelCreationInfo> data)
+        {
+            LevelData = data;
+            _resetEvent.Reset();
+        }
+
+        public void Execute(UIApplication uiapp)
+        {
+            _uiApp = uiapp;
+
+            try
+            {
+                var createdLevels = new List<LevelResultInfo>();
+                var warnings = new List<string>();
+
+                // Get all existing level names to check for duplicates
+                var existingLevels = new FilteredElementCollector(_doc)
+                    .OfClass(typeof(Level))
+                    .Cast<Level>()
+                    .ToList();
+
+                HashSet<string> existingLevelNames = new HashSet<string>(
+                    existingLevels.Select(l => l.Name),
+                    StringComparer.OrdinalIgnoreCase);
+
+                foreach (var levelInfo in LevelData)
+                {
+                    using (Transaction tx = new Transaction(_doc, "Create Level"))
+                    {
+                        tx.Start();
+
+                        try
+                        {
+                            // Check if level with same name already exists
+                            if (existingLevelNames.Contains(levelInfo.Name))
+                            {
+                                // Find existing level and return its info
+                                var existingLevel = existingLevels.FirstOrDefault(
+                                    l => l.Name.Equals(levelInfo.Name, StringComparison.OrdinalIgnoreCase));
+
+                                if (existingLevel != null)
+                                {
+                                    warnings.Add($"Level '{levelInfo.Name}' already exists at elevation {existingLevel.Elevation * 304.8:F0}mm");
+
+                                    createdLevels.Add(new LevelResultInfo
+                                    {
+#if REVIT2024_OR_GREATER
+                                        Id = (int)existingLevel.Id.Value,
+#else
+                                        Id = existingLevel.Id.IntegerValue,
+#endif
+                                        UniqueId = existingLevel.UniqueId,
+                                        Name = existingLevel.Name,
+                                        Elevation = existingLevel.Elevation * 304.8, // Convert to mm
+                                        AlreadyExisted = true
+                                    });
+
+                                    tx.RollBack();
+                                    continue;
+                                }
+                            }
+
+                            // Convert elevation from mm to feet
+                            double elevationInFeet = levelInfo.Elevation / 304.8;
+
+                            // Create the level
+                            Level newLevel = Level.Create(_doc, elevationInFeet);
+
+                            if (newLevel != null)
+                            {
+                                // Set the level name
+                                if (!string.IsNullOrEmpty(levelInfo.Name))
+                                {
+                                    newLevel.Name = levelInfo.Name;
+                                }
+
+                                // Set building story parameter if specified
+                                Parameter buildingStoryParam = newLevel.get_Parameter(BuiltInParameter.LEVEL_IS_BUILDING_STORY);
+                                if (buildingStoryParam != null && !buildingStoryParam.IsReadOnly)
+                                {
+                                    buildingStoryParam.Set(levelInfo.IsBuildingStory ? 1 : 0);
+                                }
+
+                                // Create floor plan view if requested
+                                string floorPlanViewName = null;
+                                if (levelInfo.CreateFloorPlan)
+                                {
+                                    var floorPlanType = new FilteredElementCollector(_doc)
+                                        .OfClass(typeof(ViewFamilyType))
+                                        .Cast<ViewFamilyType>()
+                                        .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+                                    if (floorPlanType != null)
+                                    {
+                                        var floorPlanView = ViewPlan.Create(_doc, floorPlanType.Id, newLevel.Id);
+                                        if (floorPlanView != null)
+                                        {
+                                            floorPlanViewName = floorPlanView.Name;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        warnings.Add($"Could not find Floor Plan view family type for level '{levelInfo.Name}'");
+                                    }
+                                }
+
+                                // Create ceiling plan view if requested
+                                string ceilingPlanViewName = null;
+                                if (levelInfo.CreateCeilingPlan)
+                                {
+                                    var ceilingPlanType = new FilteredElementCollector(_doc)
+                                        .OfClass(typeof(ViewFamilyType))
+                                        .Cast<ViewFamilyType>()
+                                        .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.CeilingPlan);
+
+                                    if (ceilingPlanType != null)
+                                    {
+                                        var ceilingPlanView = ViewPlan.Create(_doc, ceilingPlanType.Id, newLevel.Id);
+                                        if (ceilingPlanView != null)
+                                        {
+                                            ceilingPlanViewName = ceilingPlanView.Name;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        warnings.Add($"Could not find Ceiling Plan view family type for level '{levelInfo.Name}'");
+                                    }
+                                }
+
+                                tx.Commit();
+
+                                // Add to existing names set
+                                existingLevelNames.Add(newLevel.Name);
+
+                                createdLevels.Add(new LevelResultInfo
+                                {
+#if REVIT2024_OR_GREATER
+                                    Id = (int)newLevel.Id.Value,
+#else
+                                    Id = newLevel.Id.IntegerValue,
+#endif
+                                    UniqueId = newLevel.UniqueId,
+                                    Name = newLevel.Name,
+                                    Elevation = levelInfo.Elevation,
+                                    FloorPlanViewName = floorPlanViewName,
+                                    CeilingPlanViewName = ceilingPlanViewName,
+                                    AlreadyExisted = false
+                                });
+                            }
+                            else
+                            {
+                                tx.RollBack();
+                                warnings.Add($"Failed to create level '{levelInfo.Name}'");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            tx.RollBack();
+                            warnings.Add($"Error creating level '{levelInfo.Name}': {ex.Message}");
+                        }
+                    }
+                }
+
+                string message = $"Successfully processed {createdLevels.Count} level(s)";
+                int newCount = createdLevels.Count(l => !l.AlreadyExisted);
+                int existingCount = createdLevels.Count(l => l.AlreadyExisted);
+
+                if (newCount > 0 && existingCount > 0)
+                {
+                    message = $"Created {newCount} new level(s), {existingCount} already existed";
+                }
+                else if (existingCount > 0)
+                {
+                    message = $"All {existingCount} level(s) already existed";
+                }
+                else
+                {
+                    message = $"Successfully created {newCount} level(s)";
+                }
+
+                if (warnings.Count > 0)
+                {
+                    message += "\n\n⚠ Warnings:\n  • " + string.Join("\n  • ", warnings);
+                }
+
+                Result = new AIResult<List<LevelResultInfo>>
+                {
+                    Success = true,
+                    Message = message,
+                    Response = createdLevels
+                };
+            }
+            catch (Exception ex)
+            {
+                Result = new AIResult<List<LevelResultInfo>>
+                {
+                    Success = false,
+                    Message = $"Error creating levels: {ex.Message}",
+                };
+            }
+            finally
+            {
+                _resetEvent.Set(); // Signal that the operation is complete
+            }
+        }
+
+        /// <summary>
+        /// Wait for the operation to complete
+        /// </summary>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds</param>
+        /// <returns>True if completed before timeout</returns>
+        public bool WaitForCompletion(int timeoutMilliseconds = 10000)
+        {
+            return _resetEvent.WaitOne(timeoutMilliseconds);
+        }
+
+        /// <summary>
+        /// IExternalEventHandler.GetName implementation
+        /// </summary>
+        public string GetName()
+        {
+            return "Create Level";
+        }
+    }
+
+    /// <summary>
+    /// Result information for a created level
+    /// </summary>
+    public class LevelResultInfo
+    {
+        public int Id { get; set; }
+        public string UniqueId { get; set; }
+        public string Name { get; set; }
+        public double Elevation { get; set; }
+        public string FloorPlanViewName { get; set; }
+        public string CeilingPlanViewName { get; set; }
+        public bool AlreadyExisted { get; set; }
+    }
+}

--- a/revit-mcp-commandset/Services/Architecture/CreateLevelEventHandler.cs
+++ b/revit-mcp-commandset/Services/Architecture/CreateLevelEventHandler.cs
@@ -1,6 +1,7 @@
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using RevitMCPCommandSet.Models.Common;
+using RevitMCPCommandSet.Utils;
 using RevitMCPSDK.API.Interfaces;
 using LevelCreationInfo = RevitMCPCommandSet.Models.Architecture.LevelInfo;
 
@@ -79,11 +80,7 @@ namespace RevitMCPCommandSet.Services.Architecture
 
                                     createdLevels.Add(new LevelResultInfo
                                     {
-#if REVIT2024_OR_GREATER
-                                        Id = (int)existingLevel.Id.Value,
-#else
-                                        Id = existingLevel.Id.IntegerValue,
-#endif
+                                        Id = existingLevel.Id.GetIntValue(),
                                         UniqueId = existingLevel.UniqueId,
                                         Name = existingLevel.Name,
                                         Elevation = existingLevel.Elevation * 304.8, // Convert to mm
@@ -169,11 +166,7 @@ namespace RevitMCPCommandSet.Services.Architecture
 
                                 createdLevels.Add(new LevelResultInfo
                                 {
-#if REVIT2024_OR_GREATER
-                                    Id = (int)newLevel.Id.Value,
-#else
-                                    Id = newLevel.Id.IntegerValue,
-#endif
+                                    Id = newLevel.Id.GetIntValue(),
                                     UniqueId = newLevel.UniqueId,
                                     Name = newLevel.Name,
                                     Elevation = levelInfo.Elevation,
@@ -196,7 +189,7 @@ namespace RevitMCPCommandSet.Services.Architecture
                     }
                 }
 
-                string message = $"Successfully processed {createdLevels.Count} level(s)";
+                string message;
                 int newCount = createdLevels.Count(l => !l.AlreadyExisted);
                 int existingCount = createdLevels.Count(l => l.AlreadyExisted);
 

--- a/revit-mcp-commandset/Services/Architecture/CreateRoomEventHandler.cs
+++ b/revit-mcp-commandset/Services/Architecture/CreateRoomEventHandler.cs
@@ -1,0 +1,483 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.UI;
+using RevitMCPCommandSet.Models.Architecture;
+using RevitMCPCommandSet.Models.Common;
+using RevitMCPSDK.API.Interfaces;
+
+namespace RevitMCPCommandSet.Services.Architecture
+{
+    /// <summary>
+    /// Failure preprocessor that handles duplicate room number warnings by allowing them to proceed.
+    /// Revit auto-assigns room numbers when creating rooms, which may conflict with existing numbers.
+    /// We handle uniqueness ourselves after creation, so we suppress these warnings.
+    /// </summary>
+    public class DuplicateRoomNumberFailurePreprocessor : IFailuresPreprocessor
+    {
+        public FailureProcessingResult PreprocessFailures(FailuresAccessor failuresAccessor)
+        {
+            IList<FailureMessageAccessor> failures = failuresAccessor.GetFailureMessages();
+
+            foreach (FailureMessageAccessor failure in failures)
+            {
+                // Handle room number duplicate warnings by deleting the warning
+                // This allows the transaction to proceed, and we'll set a unique number afterwards
+                string description = failure.GetDescriptionText();
+                if (description.Contains("Number") ||
+                    description.Contains("number") ||
+                    description.Contains("duplicate") ||
+                    description.Contains("Duplicate"))
+                {
+                    failuresAccessor.DeleteWarning(failure);
+                }
+            }
+
+            return FailureProcessingResult.Continue;
+        }
+    }
+
+    /// <summary>
+    /// Event handler for creating rooms in Revit
+    /// </summary>
+    public class CreateRoomEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
+    {
+        private UIApplication _uiApp;
+        private UIDocument _uiDoc => _uiApp.ActiveUIDocument;
+        private Document _doc => _uiDoc.Document;
+
+        /// <summary>
+        /// Event wait object for synchronization
+        /// </summary>
+        private readonly ManualResetEvent _resetEvent = new ManualResetEvent(false);
+
+        /// <summary>
+        /// Room creation data (input)
+        /// </summary>
+        public List<RoomCreationInfo> RoomData { get; private set; }
+
+        /// <summary>
+        /// Execution result (output)
+        /// </summary>
+        public AIResult<List<RoomResultInfo>> Result { get; private set; }
+
+        /// <summary>
+        /// Set the room creation parameters
+        /// </summary>
+        public void SetParameters(List<RoomCreationInfo> data)
+        {
+            RoomData = data;
+            _resetEvent.Reset();
+        }
+
+        public void Execute(UIApplication uiapp)
+        {
+            _uiApp = uiapp;
+
+            try
+            {
+                var createdRooms = new List<RoomResultInfo>();
+
+                // Get all existing room numbers to avoid duplicates
+                HashSet<string> existingRoomNumbers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var existingRooms = new FilteredElementCollector(_doc)
+                    .OfCategory(BuiltInCategory.OST_Rooms)
+                    .WhereElementIsNotElementType()
+                    .Cast<Room>()
+                    .ToList();
+
+                foreach (var existingRoom in existingRooms)
+                {
+                    if (!string.IsNullOrEmpty(existingRoom.Number))
+                    {
+                        existingRoomNumbers.Add(existingRoom.Number);
+                    }
+                }
+
+                foreach (var roomInfo in RoomData)
+                {
+                    using (Transaction tx = new Transaction(_doc, "Create Room"))
+                    {
+                        // Set up failure handling to completely suppress duplicate room number warnings
+                        // Revit auto-assigns numbers which may conflict; we set unique numbers afterwards
+                        FailureHandlingOptions failureOptions = tx.GetFailureHandlingOptions();
+                        failureOptions.SetFailuresPreprocessor(new DuplicateRoomNumberFailurePreprocessor());
+                        failureOptions.SetClearAfterRollback(true);
+                        failureOptions.SetDelayedMiniWarnings(false);
+                        tx.SetFailureHandlingOptions(failureOptions);
+
+                        tx.Start();
+
+                        // Step 1: Find or determine the level
+                        Level level = null;
+                        if (roomInfo.LevelId > 0)
+                        {
+                            // Use specified level ID
+                            level = _doc.GetElement(new ElementId(roomInfo.LevelId)) as Level;
+                        }
+
+                        if (level == null && roomInfo.Location != null)
+                        {
+                            // Find nearest level to the Z coordinate
+                            double zInFeet = roomInfo.Location.Z / 304.8;
+                            level = FindNearestLevel(zInFeet);
+                        }
+
+                        if (level == null)
+                        {
+                            // Use the first available level
+                            level = new FilteredElementCollector(_doc)
+                                .OfClass(typeof(Level))
+                                .Cast<Level>()
+                                .OrderBy(l => l.Elevation)
+                                .FirstOrDefault();
+                        }
+
+                        if (level == null)
+                        {
+                            // Skip if no level found
+                            continue;
+                        }
+
+                        // Step 2: Create the room at the specified location
+                        Room room = null;
+
+                        if (roomInfo.Location != null)
+                        {
+                            // Convert mm to feet for UV coordinates (2D point in plan)
+                            double xInFeet = roomInfo.Location.X / 304.8;
+                            double yInFeet = roomInfo.Location.Y / 304.8;
+                            UV locationUV = new UV(xInFeet, yInFeet);
+
+                            // Create room at the specified UV location on the level
+                            room = _doc.Create.NewRoom(level, locationUV);
+                        }
+
+                        if (room == null)
+                        {
+                            // If location-based creation failed, create an unplaced room
+                            // This can happen if the point is not inside an enclosed area
+                            tx.RollBack();
+                            continue;
+                        }
+
+                        // Step 3: Set room properties
+                        // Set room name
+                        if (!string.IsNullOrEmpty(roomInfo.Name))
+                        {
+                            Parameter nameParam = room.get_Parameter(BuiltInParameter.ROOM_NAME);
+                            if (nameParam != null && !nameParam.IsReadOnly)
+                            {
+                                nameParam.Set(roomInfo.Name);
+                            }
+                        }
+
+                        // Set room number (ensuring uniqueness)
+                        // IMPORTANT: Generate unique number BEFORE relying on Revit's auto-assigned number
+                        // to prevent any duplicate number warnings
+                        string roomNumber = roomInfo.Number;
+                        if (!string.IsNullOrEmpty(roomNumber))
+                        {
+                            // User provided a number - make it unique if it already exists
+                            roomNumber = GetUniqueRoomNumber(roomNumber, existingRoomNumbers);
+                        }
+                        else
+                        {
+                            // No number provided - generate next available number (don't use room.Number)
+                            roomNumber = GetNextAvailableRoomNumber(existingRoomNumbers);
+                        }
+
+                        Parameter numberParam = room.get_Parameter(BuiltInParameter.ROOM_NUMBER);
+                        if (numberParam != null && !numberParam.IsReadOnly)
+                        {
+                            numberParam.Set(roomNumber);
+                            // Add to tracking set to avoid duplicates in same batch
+                            existingRoomNumbers.Add(roomNumber);
+                        }
+
+                        // Set upper limit if specified
+                        if (roomInfo.UpperLimitId > 0)
+                        {
+                            Parameter upperLimitParam = room.get_Parameter(BuiltInParameter.ROOM_UPPER_LEVEL);
+                            if (upperLimitParam != null && !upperLimitParam.IsReadOnly)
+                            {
+                                upperLimitParam.Set(new ElementId(roomInfo.UpperLimitId));
+                            }
+                        }
+
+                        // Set limit offset if specified (convert mm to feet)
+                        if (roomInfo.LimitOffset > 0)
+                        {
+                            Parameter limitOffsetParam = room.get_Parameter(BuiltInParameter.ROOM_UPPER_OFFSET);
+                            if (limitOffsetParam != null && !limitOffsetParam.IsReadOnly)
+                            {
+                                limitOffsetParam.Set(roomInfo.LimitOffset / 304.8);
+                            }
+                        }
+
+                        // Set base offset if specified (convert mm to feet)
+                        if (roomInfo.BaseOffset != 0)
+                        {
+                            Parameter baseOffsetParam = room.get_Parameter(BuiltInParameter.ROOM_LOWER_OFFSET);
+                            if (baseOffsetParam != null && !baseOffsetParam.IsReadOnly)
+                            {
+                                baseOffsetParam.Set(roomInfo.BaseOffset / 304.8);
+                            }
+                        }
+
+                        // Set department if provided
+                        if (!string.IsNullOrEmpty(roomInfo.Department))
+                        {
+                            Parameter deptParam = room.get_Parameter(BuiltInParameter.ROOM_DEPARTMENT);
+                            if (deptParam != null && !deptParam.IsReadOnly)
+                            {
+                                deptParam.Set(roomInfo.Department);
+                            }
+                        }
+
+                        // Set comments if provided
+                        if (!string.IsNullOrEmpty(roomInfo.Comments))
+                        {
+                            Parameter commentsParam = room.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                            if (commentsParam != null && !commentsParam.IsReadOnly)
+                            {
+                                commentsParam.Set(roomInfo.Comments);
+                            }
+                        }
+
+                        tx.Commit();
+
+                        // Add to result list
+                        createdRooms.Add(new RoomResultInfo
+                        {
+#if REVIT2024_OR_GREATER
+                            Id = (int)room.Id.Value,
+#else
+                            Id = room.Id.IntegerValue,
+#endif
+                            UniqueId = room.UniqueId,
+                            Name = roomInfo.Name ?? "Room",
+                            Number = roomNumber, // Use the actual assigned number (may differ from requested if made unique)
+                            RequestedNumber = roomInfo.Number, // Original requested number
+                            LevelName = level.Name,
+                            Area = room.Area,
+                            Perimeter = room.Perimeter
+                        });
+                    }
+                }
+
+                Result = new AIResult<List<RoomResultInfo>>
+                {
+                    Success = true,
+                    Message = $"Successfully created {createdRooms.Count} room(s)",
+                    Response = createdRooms
+                };
+            }
+            catch (Exception ex)
+            {
+                Result = new AIResult<List<RoomResultInfo>>
+                {
+                    Success = false,
+                    Message = $"Error creating rooms: {ex.Message}",
+                };
+                TaskDialog.Show("Error", $"Error creating rooms: {ex.Message}");
+            }
+            finally
+            {
+                _resetEvent.Set(); // Signal that the operation is complete
+            }
+        }
+
+        /// <summary>
+        /// Find the nearest level to a given elevation
+        /// </summary>
+        private Level FindNearestLevel(double elevationInFeet)
+        {
+            var levels = new FilteredElementCollector(_doc)
+                .OfClass(typeof(Level))
+                .Cast<Level>()
+                .ToList();
+
+            Level nearestLevel = null;
+            double minDistance = double.MaxValue;
+
+            foreach (var level in levels)
+            {
+                double distance = Math.Abs(level.Elevation - elevationInFeet);
+                if (distance < minDistance)
+                {
+                    minDistance = distance;
+                    nearestLevel = level;
+                }
+            }
+
+            return nearestLevel;
+        }
+
+        /// <summary>
+        /// Get the next available room number by finding the highest existing number and incrementing
+        /// </summary>
+        /// <param name="existingNumbers">Set of existing room numbers</param>
+        /// <returns>A guaranteed unique room number</returns>
+        private string GetNextAvailableRoomNumber(HashSet<string> existingNumbers)
+        {
+            // Find the highest numeric room number and increment from there
+            int maxNumber = 0;
+            foreach (string num in existingNumbers)
+            {
+                // Try to parse the entire string as a number
+                if (int.TryParse(num, out int parsed))
+                {
+                    if (parsed > maxNumber) maxNumber = parsed;
+                }
+                else
+                {
+                    // Try to extract trailing digits (e.g., "Room 101" -> 101)
+                    string digits = "";
+                    for (int i = num.Length - 1; i >= 0; i--)
+                    {
+                        if (char.IsDigit(num[i]))
+                            digits = num[i] + digits;
+                        else if (digits.Length > 0)
+                            break;
+                    }
+                    if (digits.Length > 0 && int.TryParse(digits, out int trailingNum))
+                    {
+                        if (trailingNum > maxNumber) maxNumber = trailingNum;
+                    }
+                }
+            }
+
+            // Start from maxNumber + 1 and find next available
+            for (int i = maxNumber + 1; i < maxNumber + 10000; i++)
+            {
+                string candidate = i.ToString();
+                if (!existingNumbers.Contains(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            // Fallback (should never reach here)
+            return (maxNumber + 1).ToString();
+        }
+
+        /// <summary>
+        /// Get a unique room number by adding a suffix if the number already exists
+        /// </summary>
+        /// <param name="baseNumber">The desired room number</param>
+        /// <param name="existingNumbers">Set of existing room numbers</param>
+        /// <returns>A unique room number</returns>
+        private string GetUniqueRoomNumber(string baseNumber, HashSet<string> existingNumbers)
+        {
+            if (string.IsNullOrEmpty(baseNumber))
+            {
+                baseNumber = "1";
+            }
+
+            // If the number doesn't exist, use it as-is
+            if (!existingNumbers.Contains(baseNumber))
+            {
+                return baseNumber;
+            }
+
+            // Try to extract numeric portion and increment
+            // Handle cases like "101", "101A", "Room 101", etc.
+            string prefix = "";
+            string numericPart = "";
+            string suffix = "";
+
+            // Find the last sequence of digits in the string
+            int lastDigitEnd = -1;
+            int lastDigitStart = -1;
+            for (int i = baseNumber.Length - 1; i >= 0; i--)
+            {
+                if (char.IsDigit(baseNumber[i]))
+                {
+                    if (lastDigitEnd == -1) lastDigitEnd = i;
+                    lastDigitStart = i;
+                }
+                else if (lastDigitEnd != -1)
+                {
+                    break;
+                }
+            }
+
+            if (lastDigitStart != -1)
+            {
+                prefix = baseNumber.Substring(0, lastDigitStart);
+                numericPart = baseNumber.Substring(lastDigitStart, lastDigitEnd - lastDigitStart + 1);
+                suffix = baseNumber.Substring(lastDigitEnd + 1);
+
+                // Try incrementing the numeric part
+                if (int.TryParse(numericPart, out int num))
+                {
+                    int maxAttempts = 1000;
+                    for (int i = 1; i <= maxAttempts; i++)
+                    {
+                        string candidate = prefix + (num + i).ToString().PadLeft(numericPart.Length, '0') + suffix;
+                        if (!existingNumbers.Contains(candidate))
+                        {
+                            return candidate;
+                        }
+                    }
+                }
+            }
+
+            // Fallback: append a letter suffix (A, B, C, ...)
+            for (char c = 'A'; c <= 'Z'; c++)
+            {
+                string candidate = baseNumber + c;
+                if (!existingNumbers.Contains(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            // Last resort: append a number
+            for (int i = 2; i <= 1000; i++)
+            {
+                string candidate = baseNumber + "-" + i;
+                if (!existingNumbers.Contains(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            // Should never reach here, but just in case
+            return baseNumber + "-" + Guid.NewGuid().ToString().Substring(0, 4);
+        }
+
+        /// <summary>
+        /// Wait for the operation to complete
+        /// </summary>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds</param>
+        /// <returns>True if completed before timeout</returns>
+        public bool WaitForCompletion(int timeoutMilliseconds = 10000)
+        {
+            return _resetEvent.WaitOne(timeoutMilliseconds);
+        }
+
+        /// <summary>
+        /// IExternalEventHandler.GetName implementation
+        /// </summary>
+        public string GetName()
+        {
+            return "Create Room";
+        }
+    }
+
+    /// <summary>
+    /// Result information for a created room
+    /// </summary>
+    public class RoomResultInfo
+    {
+        public int Id { get; set; }
+        public string UniqueId { get; set; }
+        public string Name { get; set; }
+        public string Number { get; set; }
+        public string RequestedNumber { get; set; } // Original requested number (may differ from Number if made unique)
+        public string LevelName { get; set; }
+        public double Area { get; set; }
+        public double Perimeter { get; set; }
+    }
+}

--- a/revit-mcp-commandset/Services/ColorSplashEventHandler.cs
+++ b/revit-mcp-commandset/Services/ColorSplashEventHandler.cs
@@ -277,8 +277,8 @@ namespace RevitMCPCommandSet.Services
                     return element?.Name ?? id.IntegerValue.ToString();
 #endif
                 case StorageType.Integer:
-#if REVIT2022_OR_GREATER
-                    // For Revit 2022+ we should use ForgeTypeId approach
+#if REVIT2023_OR_GREATER
+                    // For Revit 2023+ we should use ForgeTypeId approach
                     if (parameter.Definition is InternalDefinition internalDef)
                     {
                         try

--- a/revit-mcp-commandset/Services/ColorSplashEventHandler.cs
+++ b/revit-mcp-commandset/Services/ColorSplashEventHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Autodesk.Revit.UI;
 using Newtonsoft.Json.Linq;
+using RevitMCPCommandSet.Utils;
 using RevitMCPSDK.API.Interfaces;
 
 namespace RevitMCPCommandSet.Services
@@ -196,11 +197,7 @@ namespace RevitMCPCommandSet.Services
                             parameterValue = paramValue,
                             count = elementIds.Count,
                             color = new { r = rgb[0], g = rgb[1], b = rgb[2] },
-#if REVIT2024_OR_GREATER
-                            elementIds = elementIds.Select(id => id.Value.ToString()).ToList()
-#else
-                            elementIds = elementIds.Select(id => id.IntegerValue.ToString()).ToList()
-#endif
+                            elementIds = elementIds.Select(id => id.GetValue().ToString()).ToList()
                         });
                     }
 
@@ -261,21 +258,12 @@ namespace RevitMCPCommandSet.Services
                     return parameter.AsValueString() ?? parameter.AsDouble().ToString();
 
                 case StorageType.ElementId:
-#if REVIT2024_OR_GREATER
                     ElementId id = parameter.AsElementId();
                     if (id == ElementId.InvalidElementId)
                         return "None";
 
                     Element element = doc.GetElement(id);
-                    return element?.Name ?? id.Value.ToString();
-#else
-                    ElementId id = parameter.AsElementId();
-                    if (id == ElementId.InvalidElementId)
-                        return "None";
-
-                    Element element = doc.GetElement(id);
-                    return element?.Name ?? id.IntegerValue.ToString();
-#endif
+                    return element?.Name ?? id.GetValue().ToString();
                 case StorageType.Integer:
 #if REVIT2023_OR_GREATER
                     // For Revit 2023+ we should use ForgeTypeId approach

--- a/revit-mcp-commandset/Services/CreateLineElementEventHandler.cs
+++ b/revit-mcp-commandset/Services/CreateLineElementEventHandler.cs
@@ -76,17 +76,17 @@ namespace RevitMCPCommandSet.Services
                             {
                                 symbol = typeEle as FamilySymbol;
                                 // 获取symbol的Category对象并转换为BuiltInCategory枚举
-                                builtInCategory = (BuiltInCategory)symbol.Category.Id.IntegerValue;
+                                builtInCategory = (BuiltInCategory)(int)symbol.Category.Id.Value;
                             }
                             else if (typeEle != null && typeEle is WallType)
                             {
                                 wallType = typeEle as WallType;
-                                builtInCategory = (BuiltInCategory)wallType.Category.Id.IntegerValue;
+                                builtInCategory = (BuiltInCategory)(int)wallType.Category.Id.Value;
                             }
                             else if (typeEle != null && typeEle is DuctType)
                             {
                                 ductType = typeEle as DuctType;
-                                builtInCategory = (BuiltInCategory)ductType.Category.Id.IntegerValue;
+                                builtInCategory = (BuiltInCategory)(int)ductType.Category.Id.Value;
                             }
                         }
                     }
@@ -163,7 +163,7 @@ namespace RevitMCPCommandSet.Services
                                 );
                                 if (wall != null)
                                 {
-                                    elementIds.Add(wall.Id.IntegerValue);
+                                    elementIds.Add((int)wall.Id.Value);
                                 }
                                 break;
                             case BuiltInCategory.OST_DuctCurves:
@@ -191,7 +191,7 @@ namespace RevitMCPCommandSet.Services
                                         Parameter offsetParam = duct.get_Parameter(BuiltInParameter.RBS_OFFSET_PARAM);
                                         if (offsetParam != null)
                                             offsetParam.Set(baseOffset);
-                                        elementIds.Add(duct.Id.IntegerValue);
+                                        elementIds.Add((int)duct.Id.Value);
                                     }
                                 }
                                 break;
@@ -203,7 +203,7 @@ namespace RevitMCPCommandSet.Services
                                 var instance = doc.CreateInstance(symbol, null, JZLine.ToLine(data.LocationLine), baseLevel, topLevel, baseOffset, topOffset);
                                 if (instance != null)
                                 {
-                                    elementIds.Add(instance.Id.IntegerValue);
+                                    elementIds.Add((int)instance.Id.Value);
                                 }
                                 break;
                         }

--- a/revit-mcp-commandset/Services/CreateLineElementEventHandler.cs
+++ b/revit-mcp-commandset/Services/CreateLineElementEventHandler.cs
@@ -76,17 +76,17 @@ namespace RevitMCPCommandSet.Services
                             {
                                 symbol = typeEle as FamilySymbol;
                                 // 获取symbol的Category对象并转换为BuiltInCategory枚举
-                                builtInCategory = (BuiltInCategory)(int)symbol.Category.Id.Value;
+                                builtInCategory = (BuiltInCategory)symbol.Category.Id.GetIntValue();
                             }
                             else if (typeEle != null && typeEle is WallType)
                             {
                                 wallType = typeEle as WallType;
-                                builtInCategory = (BuiltInCategory)(int)wallType.Category.Id.Value;
+                                builtInCategory = (BuiltInCategory)wallType.Category.Id.GetIntValue();
                             }
                             else if (typeEle != null && typeEle is DuctType)
                             {
                                 ductType = typeEle as DuctType;
-                                builtInCategory = (BuiltInCategory)(int)ductType.Category.Id.Value;
+                                builtInCategory = (BuiltInCategory)ductType.Category.Id.GetIntValue();
                             }
                         }
                     }
@@ -163,7 +163,7 @@ namespace RevitMCPCommandSet.Services
                                 );
                                 if (wall != null)
                                 {
-                                    elementIds.Add((int)wall.Id.Value);
+                                    elementIds.Add(wall.Id.GetIntValue());
                                 }
                                 break;
                             case BuiltInCategory.OST_DuctCurves:
@@ -191,7 +191,7 @@ namespace RevitMCPCommandSet.Services
                                         Parameter offsetParam = duct.get_Parameter(BuiltInParameter.RBS_OFFSET_PARAM);
                                         if (offsetParam != null)
                                             offsetParam.Set(baseOffset);
-                                        elementIds.Add((int)duct.Id.Value);
+                                        elementIds.Add(duct.Id.GetIntValue());
                                     }
                                 }
                                 break;
@@ -203,7 +203,7 @@ namespace RevitMCPCommandSet.Services
                                 var instance = doc.CreateInstance(symbol, null, JZLine.ToLine(data.LocationLine), baseLevel, topLevel, baseOffset, topOffset);
                                 if (instance != null)
                                 {
-                                    elementIds.Add((int)instance.Id.Value);
+                                    elementIds.Add(instance.Id.GetIntValue());
                                 }
                                 break;
                         }

--- a/revit-mcp-commandset/Services/CreatePointElementEventHandler.cs
+++ b/revit-mcp-commandset/Services/CreatePointElementEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Revit.UI;
+using Autodesk.Revit.UI;
 using RevitMCPSDK.API.Interfaces;
 using RevitMCPCommandSet.Models.Common;
 using RevitMCPCommandSet.Utils;
@@ -70,7 +70,7 @@ namespace RevitMCPCommandSet.Services
                             {
                                 symbol = typeEle as FamilySymbol;
                                 // 获取symbol的Category对象并转换为BuiltInCategory枚举
-                                builtInCategory = (BuiltInCategory)symbol.Category.Id.IntegerValue;
+                                builtInCategory = (BuiltInCategory)(int)symbol.Category.Id.Value;
                             }
                         }
                     }
@@ -116,7 +116,7 @@ namespace RevitMCPCommandSet.Services
                                 doc.Regenerate();
                             }
 
-                            elementIds.Add(instance.Id.IntegerValue);
+                            elementIds.Add((int)instance.Id.Value);
                         }
                         //doc.Refresh();
                         transaction.Commit();

--- a/revit-mcp-commandset/Services/CreatePointElementEventHandler.cs
+++ b/revit-mcp-commandset/Services/CreatePointElementEventHandler.cs
@@ -70,7 +70,7 @@ namespace RevitMCPCommandSet.Services
                             {
                                 symbol = typeEle as FamilySymbol;
                                 // 获取symbol的Category对象并转换为BuiltInCategory枚举
-                                builtInCategory = (BuiltInCategory)(int)symbol.Category.Id.Value;
+                                builtInCategory = (BuiltInCategory)symbol.Category.Id.GetIntValue();
                             }
                         }
                     }
@@ -116,7 +116,7 @@ namespace RevitMCPCommandSet.Services
                                 doc.Regenerate();
                             }
 
-                            elementIds.Add((int)instance.Id.Value);
+                            elementIds.Add(instance.Id.GetIntValue());
                         }
                         //doc.Refresh();
                         transaction.Commit();

--- a/revit-mcp-commandset/Services/CreateSurfaceElementEventHandler.cs
+++ b/revit-mcp-commandset/Services/CreateSurfaceElementEventHandler.cs
@@ -72,12 +72,12 @@ namespace RevitMCPCommandSet.Services
                             {
                                 symbol = typeEle as FamilySymbol;
                                 // 获取symbol的Category对象并转换为BuiltInCategory枚举
-                                builtInCategory = (BuiltInCategory)symbol.Category.Id.IntegerValue;
+                                builtInCategory = (BuiltInCategory)symbol.Category.Id.GetIntValue();
                             }
                             else if (typeEle != null && typeEle is FloorType)
                             {
                                 floorType = typeEle as FloorType;
-                                builtInCategory = (BuiltInCategory)floorType.Category.Id.IntegerValue;
+                                builtInCategory = (BuiltInCategory)floorType.Category.Id.GetIntValue();
                             }
                         }
                     }
@@ -136,8 +136,8 @@ namespace RevitMCPCommandSet.Services
                                 }
                                 CurveLoop curveLoop = CurveLoop.Create(data.Boundary.OuterLoop.Select(l => JZLine.ToLine(l) as Curve).ToList());
 
-                                // 多版本
-#if REVIT2022_OR_GREATER
+                                // 多版本 - Floor.Create introduced in Revit 2022 but stable in 2023+
+#if REVIT2023_OR_GREATER
                                 floor = Floor.Create(doc, new List<CurveLoop> { curveLoop }, floorType.Id, baseLevel.Id);
 #else
                                 floor = doc.Create.NewFloor(curves, floorType, baseLevel, _structural);
@@ -146,7 +146,7 @@ namespace RevitMCPCommandSet.Services
                                 if (floor != null)
                                 {
                                     floor.get_Parameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM).Set(baseOffset);
-                                    elementIds.Add(floor.Id.IntegerValue);
+                                    elementIds.Add(floor.Id.GetIntValue());
                                 }
                                 break;
                             default:

--- a/revit-mcp-commandset/Services/DataExtraction/AnalyzeModelStatisticsEventHandler.cs
+++ b/revit-mcp-commandset/Services/DataExtraction/AnalyzeModelStatisticsEventHandler.cs
@@ -5,7 +5,11 @@ using RevitMCPSDK.API.Interfaces;
 
 namespace RevitMCPCommandSet.Services.DataExtraction
 {
-    public class AnalyzeModelStatisticsEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
+    /// <summary>
+    /// Business logic for analyzing model statistics.
+    /// This class has no RevitAPIUI dependencies and can be used directly in tests.
+    /// </summary>
+    public class AnalyzeModelStatisticsHandler
     {
         private bool _includeDetailedTypes;
 
@@ -25,12 +29,10 @@ namespace RevitMCPCommandSet.Services.DataExtraction
             return _resetEvent.WaitOne(timeoutMilliseconds);
         }
 
-        public void Execute(UIApplication app)
+        public void RunOnDocument(Document doc)
         {
             try
             {
-                var doc = app.ActiveUIDocument.Document;
-
                 // Get project name
                 string projectName = doc.Title;
 
@@ -168,6 +170,17 @@ namespace RevitMCPCommandSet.Services.DataExtraction
                 TaskCompleted = true;
                 _resetEvent.Set();
             }
+        }
+    }
+
+    /// <summary>
+    /// Event handler for analyzing model statistics in Revit
+    /// </summary>
+    public class AnalyzeModelStatisticsEventHandler : AnalyzeModelStatisticsHandler, IExternalEventHandler, IWaitableExternalEventHandler
+    {
+        public void Execute(UIApplication app)
+        {
+            RunOnDocument(app.ActiveUIDocument.Document);
         }
 
         public string GetName()

--- a/revit-mcp-commandset/Services/DataExtraction/ExportRoomDataEventHandler.cs
+++ b/revit-mcp-commandset/Services/DataExtraction/ExportRoomDataEventHandler.cs
@@ -6,7 +6,11 @@ using RevitMCPSDK.API.Interfaces;
 
 namespace RevitMCPCommandSet.Services.DataExtraction
 {
-    public class ExportRoomDataEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
+    /// <summary>
+    /// Business logic for exporting room data.
+    /// This class has no RevitAPIUI dependencies and can be used directly in tests.
+    /// </summary>
+    public class ExportRoomDataHandler
     {
         private bool _includeUnplacedRooms;
         private bool _includeNotEnclosedRooms;
@@ -28,11 +32,10 @@ namespace RevitMCPCommandSet.Services.DataExtraction
             return _resetEvent.WaitOne(timeoutMilliseconds);
         }
 
-        public void Execute(UIApplication app)
+        public void RunOnDocument(Document doc)
         {
             try
             {
-                var doc = app.ActiveUIDocument.Document;
                 var rooms = new List<RoomDataModel>();
                 double totalArea = 0;
 
@@ -99,6 +102,17 @@ namespace RevitMCPCommandSet.Services.DataExtraction
                 TaskCompleted = true;
                 _resetEvent.Set();
             }
+        }
+    }
+
+    /// <summary>
+    /// Event handler for exporting room data in Revit
+    /// </summary>
+    public class ExportRoomDataEventHandler : ExportRoomDataHandler, IExternalEventHandler, IWaitableExternalEventHandler
+    {
+        public void Execute(UIApplication app)
+        {
+            RunOnDocument(app.ActiveUIDocument.Document);
         }
 
         public string GetName()

--- a/revit-mcp-commandset/Services/DeleteElementEventHandler.cs
+++ b/revit-mcp-commandset/Services/DeleteElementEventHandler.cs
@@ -1,94 +1,95 @@
-﻿//using Autodesk.Revit.UI;
-//using RevitMCPSDK.API.Interfaces;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using RevitMCPSDK.API.Interfaces;
 
-//namespace RevitMCPCommandSet.Services
-//{
-//    public class DeleteElementEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
-//    {
-//        // 执行结果
-//        public bool IsSuccess { get; private set; }
+namespace RevitMCPCommandSet.Services
+{
+    public class DeleteElementEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
+    {
+        // 执行结果
+        public bool IsSuccess { get; private set; }
 
-//        // 成功删除的元素数量
-//        public int DeletedCount { get; private set; }
-//        // 状态同步对象
-//        public bool TaskCompleted { get; private set; }
-//        private readonly ManualResetEvent _resetEvent = new ManualResetEvent(false);
-//        // 要删除的元素ID数组
-//        public string[] ElementIds { get; set; }
-//        // 实现IWaitableExternalEventHandler接口
-//        public bool WaitForCompletion(int timeoutMilliseconds = 10000)
-//        {
-//            return _resetEvent.WaitOne(timeoutMilliseconds);
-//        }
-//        public void Execute(UIApplication app)
-//        {
-//            try
-//            {
-//                var doc = app.ActiveUIDocument.Document;
-//                DeletedCount = 0;
-//                if (ElementIds == null || ElementIds.Length == 0)
-//                {
-//                    IsSuccess = false;
-//                    return;
-//                }
-//                // 创建待删除元素ID集合
-//                List<ElementId> elementIdsToDelete = new List<ElementId>();
-//                List<string> invalidIds = new List<string>();
-//                foreach (var idStr in ElementIds)
-//                {
-//                    if (int.TryParse(idStr, out int elementIdValue))
-//                    {
-//                        var elementId = new ElementId(elementIdValue);
-//                        // 检查元素是否存在
-//                        if (doc.GetElement(elementId) != null)
-//                        {
-//                            elementIdsToDelete.Add(elementId);
-//                        }
-//                    }
-//                    else
-//                    {
-//                        invalidIds.Add(idStr);
-//                    }
-//                }
-//                if (invalidIds.Count > 0)
-//                {
-//                    TaskDialog.Show("警告", $"以下ID无效或元素不存在：{string.Join(", ", invalidIds)}");
-//                }
-//                // 如果有可删除的元素，则执行删除
-//                if (elementIdsToDelete.Count > 0)
-//                {
-//                    using (var transaction = new Transaction(doc, "Delete Elements"))
-//                    {
-//                        transaction.Start();
+        // 成功删除的元素数量
+        public int DeletedCount { get; private set; }
+        // 状态同步对象
+        public bool TaskCompleted { get; private set; }
+        private readonly ManualResetEvent _resetEvent = new ManualResetEvent(false);
+        // 要删除的元素ID数组
+        public string[] ElementIds { get; set; }
+        // 实现IWaitableExternalEventHandler接口
+        public bool WaitForCompletion(int timeoutMilliseconds = 10000)
+        {
+            return _resetEvent.WaitOne(timeoutMilliseconds);
+        }
+        public void Execute(UIApplication app)
+        {
+            try
+            {
+                var doc = app.ActiveUIDocument.Document;
+                DeletedCount = 0;
+                if (ElementIds == null || ElementIds.Length == 0)
+                {
+                    IsSuccess = false;
+                    return;
+                }
+                // 创建待删除元素ID集合
+                List<ElementId> elementIdsToDelete = new List<ElementId>();
+                List<string> invalidIds = new List<string>();
+                foreach (var idStr in ElementIds)
+                {
+                    if (int.TryParse(idStr, out int elementIdValue))
+                    {
+                        var elementId = new ElementId(elementIdValue);
+                        // 检查元素是否存在
+                        if (doc.GetElement(elementId) != null)
+                        {
+                            elementIdsToDelete.Add(elementId);
+                        }
+                    }
+                    else
+                    {
+                        invalidIds.Add(idStr);
+                    }
+                }
+                if (invalidIds.Count > 0)
+                {
+                    TaskDialog.Show("警告", $"以下ID无效或元素不存在：{string.Join(", ", invalidIds)}");
+                }
+                // 如果有可删除的元素，则执行删除
+                if (elementIdsToDelete.Count > 0)
+                {
+                    using (var transaction = new Transaction(doc, "Delete Elements"))
+                    {
+                        transaction.Start();
 
-//                        // 批量删除元素
-//                        ICollection<ElementId> deletedIds = doc.Delete(elementIdsToDelete);
-//                        DeletedCount = deletedIds.Count;
+                        // 批量删除元素
+                        ICollection<ElementId> deletedIds = doc.Delete(elementIdsToDelete);
+                        DeletedCount = deletedIds.Count;
 
-//                        transaction.Commit();
-//                    }
-//                    IsSuccess = true;
-//                }
-//                else
-//                {
-//                    TaskDialog.Show("错误", "没有有效的元素可以删除");
-//                    IsSuccess = false;
-//                }
-//            }
-//            catch (Exception ex)
-//            {
-//                TaskDialog.Show("错误", "删除元素失败: " + ex.Message);
-//                IsSuccess = false;
-//            }
-//            finally
-//            {
-//                TaskCompleted = true;
-//                _resetEvent.Set();
-//            }
-//        }
-//        public string GetName()
-//        {
-//            return "删除元素";
-//        }
-//    }
-//}
+                        transaction.Commit();
+                    }
+                    IsSuccess = true;
+                }
+                else
+                {
+                    TaskDialog.Show("错误", "没有有效的元素可以删除");
+                    IsSuccess = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                TaskDialog.Show("错误", "删除元素失败: " + ex.Message);
+                IsSuccess = false;
+            }
+            finally
+            {
+                TaskCompleted = true;
+                _resetEvent.Set();
+            }
+        }
+        public string GetName()
+        {
+            return "删除元素";
+        }
+    }
+}

--- a/revit-mcp-commandset/Services/GetAvailableFamilyTypesEventHandler.cs
+++ b/revit-mcp-commandset/Services/GetAvailableFamilyTypesEventHandler.cs
@@ -39,6 +39,7 @@ namespace RevitMCPCommandSet.Services
                 systemTypes.AddRange(new FilteredElementCollector(doc).OfClass(typeof(WallType)).Cast<ElementType>());
                 systemTypes.AddRange(new FilteredElementCollector(doc).OfClass(typeof(FloorType)).Cast<ElementType>());
                 systemTypes.AddRange(new FilteredElementCollector(doc).OfClass(typeof(RoofType)).Cast<ElementType>());
+                systemTypes.AddRange(new FilteredElementCollector(doc).OfClass(typeof(CeilingType)).Cast<ElementType>());
                 systemTypes.AddRange(new FilteredElementCollector(doc).OfClass(typeof(CurtainSystemType)).Cast<ElementType>());
                 // 合并结果
                 var allElements = familySymbols

--- a/revit-mcp-commandset/Services/GetCurrentViewInfoEventHandler.cs
+++ b/revit-mcp-commandset/Services/GetCurrentViewInfoEventHandler.cs
@@ -42,7 +42,7 @@ namespace RevitMCPCommandSet.Services
                     DetailLevel = activeView.DetailLevel.ToString(),
                 };
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 TaskDialog.Show("error", "获取信息失败");
             }

--- a/revit-mcp-commandset/Services/SayHelloEventHandler.cs
+++ b/revit-mcp-commandset/Services/SayHelloEventHandler.cs
@@ -1,0 +1,34 @@
+using Autodesk.Revit.UI;
+using RevitMCPSDK.API.Interfaces;
+
+namespace RevitMCPCommandSet.Services
+{
+    public class SayHelloEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
+    {
+        private readonly ManualResetEvent _resetEvent = new ManualResetEvent(false);
+
+        public string Message { get; set; } = "Hello MCP!";
+
+        public bool WaitForCompletion(int timeoutMilliseconds = 10000)
+        {
+            return _resetEvent.WaitOne(timeoutMilliseconds);
+        }
+
+        public void Execute(UIApplication app)
+        {
+            try
+            {
+                TaskDialog.Show("Revit MCP", Message);
+            }
+            finally
+            {
+                _resetEvent.Set();
+            }
+        }
+
+        public string GetName()
+        {
+            return "Say Hello";
+        }
+    }
+}

--- a/revit-mcp-commandset/Services/TagRoomsEventHandler.cs
+++ b/revit-mcp-commandset/Services/TagRoomsEventHandler.cs
@@ -1,0 +1,505 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.UI;
+using RevitMCPSDK.API.Interfaces;
+
+namespace RevitMCPCommandSet.Services
+{
+    /// <summary>
+    /// Failure preprocessor that handles duplicate room number warnings during tagging.
+    /// This suppresses warnings that might occur if the model has rooms with conflicting numbers.
+    /// </summary>
+    public class TagRoomFailurePreprocessor : IFailuresPreprocessor
+    {
+        public FailureProcessingResult PreprocessFailures(FailuresAccessor failuresAccessor)
+        {
+            IList<FailureMessageAccessor> failures = failuresAccessor.GetFailureMessages();
+
+            foreach (FailureMessageAccessor failure in failures)
+            {
+                // Handle room-related warnings by deleting them
+                string description = failure.GetDescriptionText();
+                if (description.Contains("Number") ||
+                    description.Contains("number") ||
+                    description.Contains("duplicate") ||
+                    description.Contains("Duplicate"))
+                {
+                    failuresAccessor.DeleteWarning(failure);
+                }
+            }
+
+            return FailureProcessingResult.Continue;
+        }
+    }
+
+    /// <summary>
+    /// Event handler for creating room tags in Revit
+    /// </summary>
+    public class TagRoomsEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
+    {
+        private UIApplication _uiApp;
+        private UIDocument _uiDoc => _uiApp.ActiveUIDocument;
+        private Document _doc => _uiDoc.Document;
+
+        /// <summary>
+        /// Event wait object for synchronization
+        /// </summary>
+        private readonly ManualResetEvent _resetEvent = new ManualResetEvent(false);
+
+        /// <summary>
+        /// Tagging result data
+        /// </summary>
+        public object TaggingResults { get; private set; }
+
+        private bool _useLeader;
+        private string _tagTypeId;
+        private List<int> _roomIds;
+
+        /// <summary>
+        /// Set the tagging parameters
+        /// </summary>
+        public void SetParameters(bool useLeader, string tagTypeId, List<int> roomIds = null)
+        {
+            _useLeader = useLeader;
+            _tagTypeId = tagTypeId;
+            _roomIds = roomIds;
+            _resetEvent.Reset();
+        }
+
+        public void Execute(UIApplication uiapp)
+        {
+            _uiApp = uiapp;
+            string viewSwitchMessage = null;
+
+            try
+            {
+                View activeView = _doc.ActiveView;
+
+                // First, determine the target level from the rooms we need to tag
+                Level targetLevel = null;
+                if (_roomIds != null && _roomIds.Count > 0)
+                {
+                    // Get level from specified rooms
+                    var firstRoom = _doc.GetElement(new ElementId(_roomIds[0])) as Room;
+                    if (firstRoom != null)
+                    {
+                        targetLevel = _doc.GetElement(firstRoom.LevelId) as Level;
+                    }
+                }
+                else
+                {
+                    // Get level from any room in the project
+                    var anyRoom = new FilteredElementCollector(_doc)
+                        .OfCategory(BuiltInCategory.OST_Rooms)
+                        .WhereElementIsNotElementType()
+                        .Cast<Room>()
+                        .FirstOrDefault(r => r.Area > 0);
+
+                    if (anyRoom != null)
+                    {
+                        targetLevel = _doc.GetElement(anyRoom.LevelId) as Level;
+                    }
+                }
+
+                // Check if current view supports room tags AND is on the correct level
+                bool isCorrectViewType = activeView.ViewType == ViewType.FloorPlan ||
+                                         activeView.ViewType == ViewType.CeilingPlan;
+
+                bool isCorrectLevel = false;
+                if (isCorrectViewType && activeView is ViewPlan viewPlan && targetLevel != null)
+                {
+                    isCorrectLevel = viewPlan.GenLevel != null && viewPlan.GenLevel.Id == targetLevel.Id;
+                }
+
+                bool needsViewSwitch = !isCorrectViewType || !isCorrectLevel;
+
+                if (needsViewSwitch)
+                {
+                    if (targetLevel != null)
+                    {
+                        // Find a floor plan view for this level
+                        var floorPlanView = new FilteredElementCollector(_doc)
+                            .OfClass(typeof(ViewPlan))
+                            .Cast<ViewPlan>()
+                            .FirstOrDefault(v => v.ViewType == ViewType.FloorPlan &&
+                                                 !v.IsTemplate &&
+                                                 v.GenLevel != null &&
+                                                 v.GenLevel.Id == targetLevel.Id);
+
+                        if (floorPlanView != null)
+                        {
+                            string previousViewName = activeView.Name;
+                            _uiDoc.ActiveView = floorPlanView;
+                            activeView = floorPlanView;
+                            viewSwitchMessage = $"Switched from '{previousViewName}' to '{floorPlanView.Name}' for room tagging";
+                        }
+                        else
+                        {
+                            // No suitable floor plan found
+                            TaggingResults = new
+                            {
+                                success = false,
+                                message = $"Cannot tag rooms: Current view '{activeView.Name}' ({activeView.ViewType}) does not support room tags, and no floor plan view was found for level '{targetLevel.Name}'."
+                            };
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        TaggingResults = new
+                        {
+                            success = false,
+                            message = $"Cannot tag rooms: Current view '{activeView.Name}' ({activeView.ViewType}) does not support room tags, and no rooms were found to determine the appropriate level."
+                        };
+                        return;
+                    }
+                }
+
+                // Get rooms to tag
+                ICollection<Element> rooms;
+
+                if (_roomIds != null && _roomIds.Count > 0)
+                {
+                    // Get specific rooms by ID
+                    rooms = _roomIds
+                        .Select(id => _doc.GetElement(new ElementId(id)))
+                        .Where(e => e != null && e is Room)
+                        .ToList();
+                }
+                else
+                {
+                    // Get all rooms in the current view
+                    FilteredElementCollector roomCollector = new FilteredElementCollector(_doc, activeView.Id);
+                    rooms = roomCollector.OfCategory(BuiltInCategory.OST_Rooms)
+                                         .WhereElementIsNotElementType()
+                                         .ToElements();
+                }
+
+                // Create room tags
+                List<object> createdTags = new List<object>();
+                List<string> errors = new List<string>();
+                List<object> skippedRooms = new List<object>();
+
+                // Get existing room tags in the view to avoid duplicates
+                HashSet<long> roomsWithExistingTags = new HashSet<long>();
+                FilteredElementCollector existingTagCollector = new FilteredElementCollector(_doc, activeView.Id);
+                var existingRoomTags = existingTagCollector.OfCategory(BuiltInCategory.OST_RoomTags)
+                                                          .WhereElementIsNotElementType()
+                                                          .Cast<RoomTag>()
+                                                          .ToList();
+
+                foreach (RoomTag existingTag in existingRoomTags)
+                {
+                    if (existingTag.Room != null)
+                    {
+#if REVIT2024_OR_GREATER
+                        roomsWithExistingTags.Add(existingTag.Room.Id.Value);
+#else
+                        roomsWithExistingTags.Add(existingTag.Room.Id.IntegerValue);
+#endif
+                    }
+                }
+
+                using (Transaction tran = new Transaction(_doc, "Tag Rooms"))
+                {
+                    // Set up failure handling to completely suppress any room-related warnings
+                    FailureHandlingOptions failureOptions = tran.GetFailureHandlingOptions();
+                    failureOptions.SetFailuresPreprocessor(new TagRoomFailurePreprocessor());
+                    failureOptions.SetClearAfterRollback(true);
+                    failureOptions.SetDelayedMiniWarnings(false);
+                    tran.SetFailureHandlingOptions(failureOptions);
+
+                    tran.Start();
+
+                    // Find the room tag type
+                    FamilySymbol roomTagType = FindRoomTagType(_doc);
+
+                    if (roomTagType == null)
+                    {
+                        TaggingResults = new
+                        {
+                            success = false,
+                            message = "No room tag family type found in the project"
+                        };
+                        tran.RollBack();
+                        return;
+                    }
+
+                    // Ensure tag type is active
+                    if (!roomTagType.IsActive)
+                    {
+                        roomTagType.Activate();
+                        _doc.Regenerate();
+                    }
+
+                    // Create tags for each room
+                    foreach (Element element in rooms)
+                    {
+                        Room room = element as Room;
+                        if (room == null) continue;
+
+                        // Skip unplaced or not enclosed rooms
+                        if (room.Area <= 0) continue;
+
+#if REVIT2024_OR_GREATER
+                        // Skip rooms that already have tags
+                        if (roomsWithExistingTags.Contains(room.Id.Value))
+                        {
+                            skippedRooms.Add(new
+                            {
+                                roomId = room.Id.Value.ToString(),
+                                roomName = room.get_Parameter(BuiltInParameter.ROOM_NAME)?.AsString() ?? "Room",
+                                roomNumber = room.Number,
+                                reason = "Room already has a tag in this view"
+                            });
+                            continue;
+                        }
+
+                        try
+                        {
+                            // Get the room's location point
+                            LocationPoint locPoint = room.Location as LocationPoint;
+                            XYZ roomCenter;
+
+                            if (locPoint != null)
+                            {
+                                roomCenter = locPoint.Point;
+                            }
+                            else
+                            {
+                                // Fallback: get center from bounding box
+                                BoundingBoxXYZ bbox = room.get_BoundingBox(activeView);
+                                if (bbox == null) continue;
+                                roomCenter = (bbox.Min + bbox.Max) / 2;
+                            }
+
+                            // Create UV point for room tag
+                            UV tagPoint = new UV(roomCenter.X, roomCenter.Y);
+
+                            // Create the room tag
+                            RoomTag tag = _doc.Create.NewRoomTag(
+                                new LinkElementId(room.Id),
+                                tagPoint,
+                                activeView.Id);
+
+                            if (tag != null)
+                            {
+                                // Set leader if requested
+                                if (_useLeader)
+                                {
+                                    tag.HasLeader = true;
+                                }
+
+                                createdTags.Add(new
+                                {
+                                    tagId = tag.Id.Value.ToString(),
+                                    roomId = room.Id.Value.ToString(),
+                                    roomName = room.get_Parameter(BuiltInParameter.ROOM_NAME)?.AsString() ?? "Room",
+                                    roomNumber = room.Number,
+                                    location = new
+                                    {
+                                        x = roomCenter.X * 304.8, // Convert to mm
+                                        y = roomCenter.Y * 304.8,
+                                        z = roomCenter.Z * 304.8
+                                    }
+                                });
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            errors.Add($"Error tagging room {room.Id.Value}: {ex.Message}");
+                        }
+#else
+                        // Skip rooms that already have tags
+                        if (roomsWithExistingTags.Contains(room.Id.IntegerValue))
+                        {
+                            skippedRooms.Add(new
+                            {
+                                roomId = room.Id.IntegerValue.ToString(),
+                                roomName = room.get_Parameter(BuiltInParameter.ROOM_NAME)?.AsString() ?? "Room",
+                                roomNumber = room.Number,
+                                reason = "Room already has a tag in this view"
+                            });
+                            continue;
+                        }
+
+                        try
+                        {
+                            // Get the room's location point
+                            LocationPoint locPoint = room.Location as LocationPoint;
+                            XYZ roomCenter;
+
+                            if (locPoint != null)
+                            {
+                                roomCenter = locPoint.Point;
+                            }
+                            else
+                            {
+                                // Fallback: get center from bounding box
+                                BoundingBoxXYZ bbox = room.get_BoundingBox(activeView);
+                                if (bbox == null) continue;
+                                roomCenter = (bbox.Min + bbox.Max) / 2;
+                            }
+
+                            // Create UV point for room tag
+                            UV tagPoint = new UV(roomCenter.X, roomCenter.Y);
+
+                            // Create the room tag
+                            RoomTag tag = _doc.Create.NewRoomTag(
+                                new LinkElementId(room.Id),
+                                tagPoint,
+                                activeView.Id);
+
+                            if (tag != null)
+                            {
+                                // Set leader if requested
+                                if (_useLeader)
+                                {
+                                    tag.HasLeader = true;
+                                }
+
+                                createdTags.Add(new
+                                {
+                                    tagId = tag.Id.IntegerValue.ToString(),
+                                    roomId = room.Id.IntegerValue.ToString(),
+                                    roomName = room.get_Parameter(BuiltInParameter.ROOM_NAME)?.AsString() ?? "Room",
+                                    roomNumber = room.Number,
+                                    location = new
+                                    {
+                                        x = roomCenter.X * 304.8, // Convert to mm
+                                        y = roomCenter.Y * 304.8,
+                                        z = roomCenter.Z * 304.8
+                                    }
+                                });
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            errors.Add($"Error tagging room {room.Id.IntegerValue}: {ex.Message}");
+                        }
+#endif
+                    }
+
+                    tran.Commit();
+
+                    string resultMessage = skippedRooms.Count > 0
+                        ? $"Created {createdTags.Count} tags. Skipped {skippedRooms.Count} rooms that already had tags."
+                        : $"Successfully created {createdTags.Count} room tags.";
+
+                    if (viewSwitchMessage != null)
+                    {
+                        resultMessage = viewSwitchMessage + "\n" + resultMessage;
+                    }
+
+                    TaggingResults = new
+                    {
+                        success = true,
+                        totalRooms = rooms.Count,
+                        taggedRooms = createdTags.Count,
+                        skippedCount = skippedRooms.Count,
+                        tags = createdTags,
+                        skippedRooms = skippedRooms.Count > 0 ? skippedRooms : null,
+                        errors = errors.Count > 0 ? errors : null,
+                        viewSwitched = viewSwitchMessage != null,
+                        message = resultMessage
+                    };
+                }
+            }
+            catch (Exception ex)
+            {
+                TaskDialog.Show("Error", $"Error tagging rooms: {ex.Message}");
+                TaggingResults = new
+                {
+                    success = false,
+                    message = $"Error occurred: {ex.Message}"
+                };
+            }
+            finally
+            {
+                _resetEvent.Set(); // Signal that the operation is complete
+            }
+        }
+
+        /// <summary>
+        /// Wait for the operation to complete
+        /// </summary>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds</param>
+        /// <returns>True if completed before timeout</returns>
+        public bool WaitForCompletion(int timeoutMilliseconds = 10000)
+        {
+            return _resetEvent.WaitOne(timeoutMilliseconds);
+        }
+
+        /// <summary>
+        /// IExternalEventHandler.GetName implementation
+        /// </summary>
+        public string GetName()
+        {
+            return "Tag Rooms";
+        }
+
+        /// <summary>
+        /// Find the room tag type in the document
+        /// </summary>
+        private FamilySymbol FindRoomTagType(Document doc)
+        {
+#if REVIT2024_OR_GREATER
+            // If specific tag type ID was specified, try to use it
+            if (!string.IsNullOrEmpty(_tagTypeId))
+            {
+                if (int.TryParse(_tagTypeId, out int id))
+                {
+                    ElementId elementId = new ElementId(id);
+                    Element element = doc.GetElement(elementId);
+
+                    if (element != null && element is FamilySymbol symbol &&
+                        symbol.Category != null &&
+                        symbol.Category.Id.Value == (int)BuiltInCategory.OST_RoomTags)
+                    {
+                        return symbol;
+                    }
+                }
+            }
+
+            // Find the first available room tag type
+            FilteredElementCollector tagCollector = new FilteredElementCollector(doc);
+            FamilySymbol roomTagType = tagCollector.OfClass(typeof(FamilySymbol))
+                                                  .WhereElementIsElementType()
+                                                  .Where(e => e.Category != null &&
+                                                         e.Category.Id.Value == (int)BuiltInCategory.OST_RoomTags)
+                                                  .Cast<FamilySymbol>()
+                                                  .FirstOrDefault();
+
+            return roomTagType;
+#else
+            // If specific tag type ID was specified, try to use it
+            if (!string.IsNullOrEmpty(_tagTypeId))
+            {
+                if (int.TryParse(_tagTypeId, out int id))
+                {
+                    ElementId elementId = new ElementId(id);
+                    Element element = doc.GetElement(elementId);
+
+                    if (element != null && element is FamilySymbol symbol &&
+                        symbol.Category != null &&
+                        symbol.Category.Id.IntegerValue == (int)BuiltInCategory.OST_RoomTags)
+                    {
+                        return symbol;
+                    }
+                }
+            }
+
+            // Find the first available room tag type
+            FilteredElementCollector tagCollector = new FilteredElementCollector(doc);
+            FamilySymbol roomTagType = tagCollector.OfClass(typeof(FamilySymbol))
+                                                  .WhereElementIsElementType()
+                                                  .Where(e => e.Category != null &&
+                                                         e.Category.Id.IntegerValue == (int)BuiltInCategory.OST_RoomTags)
+                                                  .Cast<FamilySymbol>()
+                                                  .FirstOrDefault();
+
+            return roomTagType;
+#endif
+        }
+    }
+}

--- a/revit-mcp-commandset/Services/TagRoomsEventHandler.cs
+++ b/revit-mcp-commandset/Services/TagRoomsEventHandler.cs
@@ -1,6 +1,7 @@
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.UI;
+using RevitMCPCommandSet.Utils;
 using RevitMCPSDK.API.Interfaces;
 
 namespace RevitMCPCommandSet.Services

--- a/revit-mcp-commandset/Services/TagWallsEventHandler.cs
+++ b/revit-mcp-commandset/Services/TagWallsEventHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Autodesk.Revit.UI;
+using RevitMCPCommandSet.Utils;
 using RevitMCPSDK.API.Interfaces;
 
 namespace RevitMCPCommandSet.Services

--- a/revit-mcp-commandset/Utils/ElementIdExtensions.cs
+++ b/revit-mcp-commandset/Utils/ElementIdExtensions.cs
@@ -1,0 +1,31 @@
+using Autodesk.Revit.DB;
+
+namespace RevitMCPCommandSet.Utils
+{
+    /// <summary>
+    /// Extension methods for ElementId to handle API differences between Revit versions.
+    /// In Revit 2024+, ElementId.Value returns long.
+    /// In earlier versions, ElementId.IntegerValue returns int.
+    /// </summary>
+    public static class ElementIdExtensions
+    {
+        /// <summary>
+        /// Gets the numeric value of an ElementId as a long, compatible with all Revit versions.
+        /// </summary>
+#if REVIT2024_OR_GREATER
+        public static long GetValue(this ElementId id) => id.Value;
+#else
+        public static long GetValue(this ElementId id) => id.IntegerValue;
+#endif
+
+        /// <summary>
+        /// Gets the numeric value of an ElementId as an int, compatible with all Revit versions.
+        /// Use this when you need an int (e.g., for serialization to existing schemas).
+        /// </summary>
+#if REVIT2024_OR_GREATER
+        public static int GetIntValue(this ElementId id) => (int)id.Value;
+#else
+        public static int GetIntValue(this ElementId id) => id.IntegerValue;
+#endif
+    }
+}

--- a/revit-mcp-commandset/Utils/GeometryUtils.cs
+++ b/revit-mcp-commandset/Utils/GeometryUtils.cs
@@ -203,8 +203,10 @@ public static class GeometryUtils
     {
         // Implement algorithm to calculate intersection
         // Simple method: use Revit API to find intersection
+#pragma warning disable CS0618 // Maintain backwards compatibility with pre-2026 Revit API
         var results = new IntersectionResultArray();
         if (line1.Intersect(line2, out results) == SetComparisonResult.Overlap && results.Size > 0)
+#pragma warning restore CS0618
             return results.get_Item(0).XYZPoint;
         return null;
     }

--- a/revit-mcp-commandset/Utils/ProjectUtils.cs
+++ b/revit-mcp-commandset/Utils/ProjectUtils.cs
@@ -113,7 +113,7 @@ namespace RevitMCPCommandSet.Utils
                         throw new ArgumentNullException($"必要参数{typeof(Level)} {nameof(baseLevel)}缺失！");
                     // 判断是结构柱还是建筑柱
                     StructuralType structuralType = StructuralType.NonStructural;
-                    if (familySymbol.Category.Id.IntegerValue == (int)BuiltInCategory.OST_StructuralColumns)
+                    if ((int)familySymbol.Category.Id.Value == (int)BuiltInCategory.OST_StructuralColumns)
                         structuralType = StructuralType.Column;
                     instance = doc.Create.NewFamilyInstance(
                         locationPoint,              // 实例将被放置的物理位置
@@ -868,7 +868,7 @@ namespace RevitMCPCommandSet.Utils
                  .FirstOrDefault(l => l.Name == levelName);
             if (namesakeLevel != null)
             {
-                levelName = $"{levelName}_{newLevel.Id.IntegerValue.ToString()}";
+                levelName = $"{levelName}_{newLevel.Id.Value.ToString()}";
             }
             newLevel.Name = levelName;
 

--- a/revit-mcp-commandset/Utils/ProjectUtils.cs
+++ b/revit-mcp-commandset/Utils/ProjectUtils.cs
@@ -113,7 +113,7 @@ namespace RevitMCPCommandSet.Utils
                         throw new ArgumentNullException($"必要参数{typeof(Level)} {nameof(baseLevel)}缺失！");
                     // 判断是结构柱还是建筑柱
                     StructuralType structuralType = StructuralType.NonStructural;
-                    if ((int)familySymbol.Category.Id.Value == (int)BuiltInCategory.OST_StructuralColumns)
+                    if (familySymbol.Category.Id.GetIntValue() == (int)BuiltInCategory.OST_StructuralColumns)
                         structuralType = StructuralType.Column;
                     instance = doc.Create.NewFamilyInstance(
                         locationPoint,              // 实例将被放置的物理位置
@@ -868,7 +868,7 @@ namespace RevitMCPCommandSet.Utils
                  .FirstOrDefault(l => l.Name == levelName);
             if (namesakeLevel != null)
             {
-                levelName = $"{levelName}_{newLevel.Id.Value.ToString()}";
+                levelName = $"{levelName}_{newLevel.Id.GetValue()}";
             }
             newLevel.Name = levelName;
 


### PR DESCRIPTION
Hi 👋,

This is part 3 of the [Sparx-Fire](https://github.com/sparx-fire) contributions to the mcp-servers-for-revit project. Please see the extended description in [part 1](https://github.com/mcp-servers-for-revit/revit-mcp/pull/33) for the full context of these changes.

This PR adds a build configuration for Revit 2026, fixes some build errors, and adds support for additional commands (matching the PR in the MCP server repo):

- New Commands                                                                                                                                                                
  - say_hello - Test greeting dialog
  - create_room - Create and place rooms with custom names, numbers, and properties
  - tag_rooms - Tag all rooms in the current view with room name and number
  - create_level - Create levels at specified elevations with automatic floor plan generation
- Newly Registered Commands (code existed, now wired up in command.json)
  - get_selected_elements
  - create_point_based_element
  - create_surface_based_element
  - color_splash
  - ai_element_filter
  - operate_element
- Modified Commands
  - tag_all_walls renamed to tag_walls
  - create_Wall removed (superseded by create_line_based_element)
  - delete_element re-enabled (was commented out)
- Build
  - Added Revit 2026 (R26) support
  - Added ElementIdExtensions for cross-version API compatibility