### PR TITLE
fix: expose Document with common aliases in code execution template

### DIFF
--- a/revit-mcp-commandset/Commands/ExecuteDynamicCode/ExecuteCodeEventHandler.cs
+++ b/revit-mcp-commandset/Commands/ExecuteDynamicCode/ExecuteCodeEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.CodeDom.Compiler;
+using System.CodeDom.Compiler;
 using Autodesk.Revit.UI;
 using Microsoft.CSharp;
 using Newtonsoft.Json;
@@ -92,9 +92,10 @@ namespace RevitMCPCommandSet.Commands.ExecuteDynamicCode
             // 包装代码以规范入口点
             var wrappedCode = $@"
 using System;
+using System.Linq;
+using System.Collections.Generic;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
-using System.Collections.Generic;
 
 namespace AIGeneratedCode
 {{
@@ -102,7 +103,10 @@ namespace AIGeneratedCode
     {{
         public static object Execute(Document document, object[] parameters)
         {{
-            // 用户代码入口
+            // Convenience aliases matching common Revit API patterns
+            var Document = document;
+            var Doc = document;
+            var doc = document;
             {code}
         }}
     }}


### PR DESCRIPTION
## Summary

- **Problem:** The `send_code_to_revit` tool's code execution template exposes the Revit Document only as `document` (lowercase). Users and AI models commonly expect `Document` (capital D, matching Dynamo/Revit macro conventions), leading to compilation errors and confusion.
- **Fix:** Added convenience aliases (`Document`, `Doc`, `doc`) inside the `Execute` method so user code works regardless of casing convention. Also added the missing `using System.Linq;` directive which is commonly needed for LINQ queries against Revit element collections.

## Changes

In `ExecuteCodeEventHandler.cs`, the dynamically compiled code template was updated:

1. **Added `using System.Linq;`** to the template's using statements (enables `.Where()`, `.Select()`, `.ToList()`, etc.)
2. **Added convenience aliases** at the top of the `Execute` method body:
   ```csharp
   var Document = document;
   var Doc = document;
   var doc = document;
   ```
   This allows user-submitted code to reference the active Revit Document using any of the common naming patterns (`Document`, `Doc`, `doc`, or the original `document` parameter).

## Motivation

Resolves mcp-servers-for-revit/revit-mcp#29

When AI models generate Revit API code, they overwhelmingly use `Document` (capital D) or `doc` as the variable name -- matching the conventions used in Dynamo scripts, Revit macros, and the official Revit API documentation. The previous template only had `document` (lowercase) as the parameter name, causing immediate compilation failures for nearly all AI-generated code.

## Test plan

- [ ] Verify code using `Document.` (capital D) compiles and executes correctly
- [ ] Verify code using `doc.` compiles and executes correctly  
- [ ] Verify code using `document.` (original parameter) still works
- [ ] Verify LINQ queries (e.g., `new FilteredElementCollector(doc).OfClass(typeof(Wall)).ToList()`) compile with the added `System.Linq` using

🤖 Generated with [Claude Code](https://claude.com/claude-code)